### PR TITLE
add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Add publish workflow that triggers on GitHub Release creation
- Uses OIDC trusted publishers for npm auth (no secrets needed)
- Publishes with provenance for supply chain trust

## Test plan
- [ ] CI passes
- [ ] Create a GitHub Release after merge to verify publish workflow