### PR TITLE
update readmes for Chrome Web Store launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ This library provides React bindings for that API. `<WebMCPProvider>` installs a
 
 ## Connect to AI clients
 
-Desktop MCP clients like Claude Code and Cursor can't access `navigator.modelContext` directly. This repo includes a [Chrome extension](./extension) that connects your registered tools to any MCP client.
+Desktop MCP clients like Claude Code and Cursor can't access `navigator.modelContext` directly. The [WebMCP Bridge extension](https://chromewebstore.google.com/detail/webmcp-bridge/chgjbookknohehmaocfijekhaocaanaf) connects your registered tools to any MCP client.
 
-See the [extension setup guide](./extension/README.md) for build, install, and configuration instructions.
+1. Install the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/webmcp-bridge/chgjbookknohehmaocfijekhaocaanaf)
+2. Configure your MCP client — see the [extension setup guide](./extension/README.md) for details
 
 Once Chrome supports this bridging natively, I'll deprecate the extension.
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -28,12 +28,9 @@ pnpm build
 
 ### 2. Install in Chrome
 
-1. Open `chrome://extensions/`
-2. Enable **Developer mode** (top right)
-3. Click **Load unpacked**
-4. Select the `extension/dist/` directory
+Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/webmcp-bridge/chgjbookknohehmaocfijekhaocaanaf).
 
-I'll try to release it on the Chrome Webstore so it's easier to install.
+For development, you can also load from source — see [Development](#development) below.
 
 ### 3. Configure your MCP client
 
@@ -90,6 +87,8 @@ Tools from different tabs are namespaced as `tab-{tabId}:{toolName}` to avoid co
 pnpm dev
 pnpm typecheck
 ```
+
+To load from source, build the extension (`pnpm build`), then open `chrome://extensions/`, enable **Developer mode**, click **Load unpacked**, and select the `extension/dist/` directory.
 
 After rebuilding, click the reload button on `chrome://extensions/` to pick up changes.
 


### PR DESCRIPTION
## Summary

- **README.md**: "Connect to AI clients" section now links directly to the Chrome Web Store listing with a 1-2 install flow
- **extension/README.md**: "Install in Chrome" leads with the Chrome Web Store link; manual load-unpacked moved to Development section

## Test

- Check both README links resolve to the extension listing
- Verify the `[Development](#development)` anchor link works in the extension README