### PR TITLE
Reject registerTool on already-aborted signal (Chrome 152); sweep stale navigator.modelContext references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `webmcp-react` are documented here. The format is based o
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- **Already-aborted `AbortSignal` now rejects.** The polyfill's `registerTool` rejects with the
+  signal's abort reason when handed an already-aborted signal, matching WebMCP spec PR #202 and
+  native Chrome 152.0.7943.0. Previously it resolved as a no-op, matching native Chrome 151.
+  Validation errors still take precedence over the aborted-signal check. `useMcpTool` is
+  unaffected: it never passes a pre-aborted signal, and `AbortError` rejections are already
+  treated as lifecycle teardown.
+- Docs and npm keywords now reference `document.modelContext`; `navigator.modelContext` was
+  removed from Chrome as of 152.0.7943.0 (the library itself migrated in 0.2.0).
+
 ## 0.2.0
 
 Realigns the library with the current [WebMCP](https://github.com/webmachinelearning/webmcp)

--- a/docs/api.md
+++ b/docs/api.md
@@ -129,6 +129,6 @@ document.modelContext.ontoolchange = () => { /* ... */ };
 - a non-serializable `inputSchema`;
 - an `exposedTo` entry that is not a parseable, potentially-trustworthy origin.
 
-An already-aborted `AbortSignal` does **not** reject: `registerTool` resolves as a no-op (registration is skipped), matching native Chrome 151. _(WebMCP spec PR #202 specifies rejection; native had not shipped that as of Chrome 151. Revisit if native changes.)_
+An already-aborted `AbortSignal` also rejects: `registerTool` rejects with the signal's abort reason and skips registration, matching the WebMCP spec and native Chrome 152+. Validation errors take precedence — the aborted-signal check runs after the checks above.
 
 The hook routes these rejections into `state.error` and fires `onError`, except `AbortError` (lifecycle teardown), which is ignored.

--- a/examples/native-harness/src/App.tsx
+++ b/examples/native-harness/src/App.tsx
@@ -85,8 +85,9 @@ async function runSelfTest(log: (line: string) => void) {
       : `FAIL: add ${addRaw}`,
   );
 
-  // Open spec question: does registerTool with an already-aborted signal
-  // reject (our current assumption) or resolve? Probe the live backend.
+  // Spec + native Chrome 152+: registerTool with an already-aborted signal
+  // rejects with the signal's abort reason. Older native (<=151) resolved as a
+  // no-op instead.
   try {
     const result = await mc.registerTool(
       {
@@ -96,10 +97,10 @@ async function runSelfTest(log: (line: string) => void) {
       },
       { signal: AbortSignal.abort(new DOMException("probe", "AbortError")) },
     );
-    log(`INFO: already-aborted register RESOLVED (value=${String(result)})`);
+    log(`INFO: already-aborted register RESOLVED (value=${String(result)}; pre-152 native behavior)`);
   } catch (err) {
     const name = err instanceof Error ? err.name : String(err);
-    log(`INFO: already-aborted register REJECTED (${name})`);
+    log(`PASS: already-aborted register rejects (${name})`);
   }
 }
 

--- a/extension/PRIVACY.md
+++ b/extension/PRIVACY.md
@@ -1,10 +1,10 @@
 # Privacy Policy — WebMCP Bridge
 
-**Last updated:** March 2026
+**Last updated:** July 2026
 
 ## Overview
 
-WebMCP Bridge is an open-source Chrome extension that connects tools registered on web pages (via the `navigator.modelContext` browser API) to local AI assistants through Model Context Protocol (MCP). It does not collect, store, or transmit any personal data.
+WebMCP Bridge is an open-source Chrome extension that connects tools registered on web pages (via the `document.modelContext` browser API) to local AI assistants through Model Context Protocol (MCP). It does not collect, store, or transmit any personal data.
 
 ## What data does the extension access?
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,12 +1,12 @@
 # WebMCP Bridge Server Chrome Extension
 
-A Chrome extension that bridges tools registered on `navigator.modelContext` to desktop AI clients (Claude Code, Cursor, etc.) via MCP.
+A Chrome extension that bridges tools registered on `document.modelContext` to desktop AI clients (Claude Code, Cursor, etc.) via MCP.
 
 > Note: This extension is a workaround for now. Once Chrome natively supports some bridge solution, I'll deprecate this extension.
 
 ## How it works
 
-Your React app registers tools using `webmcp-react`. The extension picks them up from `navigator.modelContext`, aggregates tools across all active tabs, and exposes them through a local MCP server that clients connect to over stdio.
+Your React app registers tools using `webmcp-react`. The extension picks them up from `document.modelContext` (via the `navigator.modelContextTesting` consumer API), aggregates tools across all active tabs, and exposes them through a local MCP server that clients connect to over stdio.
 
 ![Extension architecture](./extension-architecture.svg)
 
@@ -97,7 +97,7 @@ After rebuilding, click the reload button on `chrome://extensions/` to pick up c
 ```
 src/
 ├── background.ts          # Service worker — manages tabs, tools, WebSocket
-├── content-main.ts        # Main world script — reads navigator.modelContext
+├── content-main.ts        # Main world script — reads navigator.modelContextTesting
 ├── content-isolated.ts    # Isolated world script — bridges messages
 ├── types.ts               # Shared type definitions
 ├── popup/

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react",
     "hooks",
     "ai",
-    "navigator.modelContext",
+    "document.modelContext",
     "w3c"
   ],
   "author": "Kashish Hora",

--- a/src/hooks/useMcpTool.ts
+++ b/src/hooks/useMcpTool.ts
@@ -257,9 +257,9 @@ export function useMcpTool(
     };
 
     try {
-      // Native Chrome (<=151) returns undefined and throws synchronously on error;
-      // the spec (#200) and our polyfill return a Promise<undefined> that rejects.
-      // Handle both shapes.
+      // Native Chrome <=151 returns undefined and throws synchronously on error;
+      // the spec, native Chrome 152+, and our polyfill return a Promise<undefined>
+      // that rejects. Handle both shapes.
       const result: unknown = mc.registerTool(descriptor, {
         signal: controller.signal,
         ...(cfg.exposedTo && { exposedTo: cfg.exposedTo }),

--- a/src/polyfill/__tests__/registry.test.ts
+++ b/src/polyfill/__tests__/registry.test.ts
@@ -91,11 +91,12 @@ describe("createRegistry", () => {
     ).rejects.toMatchObject({ name: "SecurityError" });
   });
 
-  it("resolves as a no-op when the signal is already aborted (matches native Chrome 151)", async () => {
+  it("rejects with the signal's abort reason when the signal is already aborted (matches native Chrome 152)", async () => {
     const registry = createRegistry();
+    const reason = new DOMException("torn down", "AbortError");
     await expect(
-      registry.registerTool(makeTool(), { signal: AbortSignal.abort() }),
-    ).resolves.toBeUndefined();
+      registry.registerTool(makeTool(), { signal: AbortSignal.abort(reason) }),
+    ).rejects.toBe(reason);
     expect(registry.getTools().has("test_tool")).toBe(false);
   });
 

--- a/src/polyfill/registry.ts
+++ b/src/polyfill/registry.ts
@@ -64,9 +64,9 @@ export function createRegistry(): RegistryInternal {
         }
       }
       if (options?.signal?.aborted) {
-        // Native Chrome (verified 151) resolves without registering when handed an
-        // already-aborted signal; match that rather than rejecting.
-        return Promise.resolve(undefined);
+        // Checked after validation — the spec gives validation errors precedence
+        // over an aborted signal, which rejects with its abort reason.
+        return Promise.reject(options.signal.reason);
       }
 
       tools.set(tool.name, {


### PR DESCRIPTION
## What changed

Chrome 152.0.7943.0 shipped two relevant changes (per the Chrome WebMCP team's EPP announcement and verified against Chromium source at the 152.0.7943.0 tag):

1. `navigator.modelContext` is now fully **removed** (deprecated since 150; this library migrated to `document.modelContext` in 0.2.0 / #23).
2. Native `registerTool` now **rejects with the signal's abort reason** when handed an already-aborted `AbortSignal` — the behavior specified by [webmcp spec PR #202](https://github.com/webmachinelearning/webmcp/pull/202) (merged June 17), which had not shipped as of Chrome 151. Our docs carried a "revisit if native changes" caveat for exactly this.

### Behavior change

- **`src/polyfill/registry.ts`** — `registerTool` with an already-aborted signal now rejects with `signal.reason` instead of resolving as a no-op. The check stays after validation, matching the spec's step order (validation errors take precedence).
- **`src/polyfill/__tests__/registry.test.ts`** — test flipped to assert rejection with the exact abort reason.
- `useMcpTool` needs no change: it never passes a pre-aborted signal, and `AbortError` rejections are already treated as lifecycle teardown.

### Doc/metadata sweep

- **extension/README.md, extension/PRIVACY.md** — `navigator.modelContext` → `document.modelContext`; the project-structure line now correctly says content-main.ts reads `navigator.modelContextTesting`. Privacy policy date bumped.
- **package.json** — npm keyword `navigator.modelContext` → `document.modelContext`.
- **docs/api.md** — aborted-signal paragraph rewritten; "revisit if native changes" caveat resolved.
- **examples/native-harness/src/App.tsx** — the "open spec question" probe comment is settled; rejection now logs PASS, resolve logs INFO (pre-152 native).
- **src/hooks/useMcpTool.ts** — comment notes native 152+ returns a Promise.
- **CHANGELOG.md** — new Unreleased section. (0.2.0 entries left as accurate history.)

## Reviewer notes

- The aborted-signal change is observable behavior of the published polyfill (no-op → rejection), so it warrants a version bump on release.
- Verified: `pnpm typecheck`, `pnpm test` (174 tests, 11 files), `pnpm lint` all pass.
