### PR TITLE
fix(deps): bump fast-uri to 3.1.7 (GHSA-fph4-wmhf-6fwf, GHSA-5jgf-p345-68v8)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1651,8 +1651,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3368,7 +3368,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3708,7 +3708,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:


### PR DESCRIPTION
## What

In-range bump of the transitive dependency `fast-uri` from **3.1.5** to **3.1.7** in the root `pnpm-lock.yaml`. Lockfile-only change (4 lines); no `package.json` edits and no other packages moved. `lockfileVersion` stays at `9.0`.

Dependency chain: `webmcp-bridge-extension` -> `@modelcontextprotocol/sdk@1.30.0` -> `ajv@8.20.0` (and `ajv-formats@3.0.1`) -> `fast-uri`. `ajv` declares `fast-uri: ^3.0.1`, so 3.1.7 (npm dist-tag `three`) resolves in range.

## Why

Two HIGH (CVSS 7.5) advisories in fast-uri URL parsing, both SSRF / host-confusion bugs:

| Alert | Advisory | CVE | Vulnerable range | Fixed in |
|---|---|---|---|---|
| #121 | GHSA-fph4-wmhf-6fwf | CVE-2026-75899 | `>=3.1.2 <3.1.6` | 3.1.6 |
| #120 | GHSA-5jgf-p345-68v8 | CVE-2026-75931 | `>=3.1.3 <3.1.6` | 3.1.6 |

Resolves Dependabot alerts #120 and #121. Dependabot does not open fix PRs in this repo (`open-pull-requests-limit: 0`), so this is the fix path.

## How it was done

```
npx -y pnpm@10 -r update fast-uri --depth Infinity
```

pnpm 10 was used to match CI (`pnpm/action-setup@v4` with `version: 10`).

## Validation (local, pnpm 10.34.5)

- `pnpm install --frozen-lockfile` passes on the updated lockfile
- `pnpm build` passes (ESM + CJS + DTS)
- `pnpm typecheck` passes
- `pnpm lint` passes (`biome check .`, 24 files, no fixes)
- `pnpm test` passes: 11 files, 174 tests
- `pnpm --filter webmcp-bridge-extension build` and `typecheck` pass
- `pnpm why -r fast-uri` shows exactly one version, 3.1.7
- `pnpm audit --audit-level=high` reports 0 high; the remaining items are unrelated (esbuild low, covered by #50; two `qs` moderate)

## Notes

`packages/webmcp-server` is outside the pnpm workspace and has no committed lockfile, so nothing to change there. Its `@modelcontextprotocol/sdk@^1.12.1` resolves to the same `ajv` -> `fast-uri ^3.0.1` chain, and a fresh install already gets 3.1.7.
