### PR TITLE
Release 1.0.0; fix playground deploy (Zod 4 alignment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to `webmcp-react` are documented here. The format is based o
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.0.0
+
+First stable release. From here on, breaking changes to the public API bump the major version.
+
+### Added
+
+- **Zod 4 support.** The `zod` peer dependency range is now `^3.25.0 || ^4.0.0`. `useMcpTool`
+  accepts Zod 4 and Zod Mini object schemas for `input` / `output`, converts them to JSON Schema
+  with Zod's native `toJSONSchema`, and validates them through `zod/v4/core`. Classic Zod 3
+  schemas keep going through `zod-to-json-schema` and `schema.parse`. Zod 3.25 is the new floor
+  because it ships the `zod/v4/core` entry point the library imports.
 
 ### Changed
 

--- a/examples/native-harness/package.json
+++ b/examples/native-harness/package.json
@@ -11,7 +11,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "webmcp-react": "workspace:*",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/react": "^19.2.18",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,7 +10,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "webmcp-react": "workspace:*",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "25.3.0",

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -10,7 +10,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "webmcp-react": "workspace:*",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/react": "^19.2.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmcp-react",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "React hooks for exposing your app's functionality as WebMCP tools - transport-agnostic, SSR-safe, Strict Mode safe, W3C spec-aligned",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: workspace:*
         version: link:../..
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/react':
         specifier: ^19.2.18
@@ -106,8 +106,8 @@ importers:
         specifier: workspace:*
         version: link:../..
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 25.3.0
@@ -134,8 +134,8 @@ importers:
         specifier: workspace:*
         version: link:../..
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/react':
         specifier: ^19.2.18
@@ -2518,9 +2518,6 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -4547,7 +4544,5 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-
-  zod@3.25.76: {}
 
   zod@4.4.3: {}


### PR DESCRIPTION
## Summary

- Bump `webmcp-react` to **1.0.0** and promote the Unreleased changelog section to `1.0.0`, adding the Zod 4 support entry from #49.
- Fix the **Deploy Playground** workflow, which has failed on `main` since #49 ([run 33792068072](https://github.com/agentcathq/webmcp-react/actions/runs/33792068072)).

## Root cause of the deploy failure

#49 moved the root `zod` devDependency to `^4.4.3` and the library types now import from `zod/v3` and `zod/v4/core`. The three example apps still pinned `zod@^3.25.76`, so pnpm installed a second copy. The playground aliases `webmcp-react` to `../../src`, so `tsc` compiled the library against root `zod@4.4.3` while the playground's own `z.object(...)` came from `zod@3.25.76`. `ZodObject` has a private `_cached` member, so TypeScript treats the two copies as different classes:

```
src/tools/GameStatusTool.tsx(14,5): error TS2769: No overload matches this call.
  Type 'ZodObject<{}, "strip", ZodTypeAny, {}, {}>' is not assignable to type 'AnyZodObject'.
    Property '_cached' is private in type 'ZodObject<...>' but not in type 'ZodObject<any, any, any, ...>'.
```

## Fix

Move `examples/playground`, `examples/nextjs`, and `examples/native-harness` to `zod@^4.4.3` so the whole workspace resolves one `zod` package. The lockfile diff only swaps the three specifiers and drops `zod@3.25.76`. All three examples use only `z.object`, `z.string`, `z.enum`, `.length`, and `.describe`, which are unchanged in Zod 4.

## Verification (local, pnpm 10 as in CI)

- `pnpm install --frozen-lockfile` passes with the regenerated lockfile.
- `GITHUB_PAGES=true pnpm --filter webmcp-react-playground build` passes (it reproduced the 4 CI errors before the fix).
- `pnpm --filter webmcp-react-native-harness build` passes; `tsc --noEmit` in `examples/nextjs` passes.
- Root `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm test` (178 tests) pass.

## Release steps after merge

1. `git tag v1.0.0 <merge commit>` and `git push origin v1.0.0`
2. `gh release create v1.0.0 --title v1.0.0 --notes-file <1.0.0 section of CHANGELOG.md>`, which triggers the Publish workflow (npm publish with provenance).

