### PR TITLE
1.1.0: execution AbortSignals + document.modelContext consumer API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ src/                    ← core library (your focus)
 ├── polyfill/           ← document.modelContext polyfill
 │   ├── index.ts        ← installPolyfill / cleanupPolyfill + polyfill marker
 │   ├── registry.ts     ← in-memory tool storage
-│   ├── testing-shim.ts ← simulates MCP client calls
+│   ├── execute.ts      ← shared execution engine (signals, serialization, errors)
+│   ├── testing-shim.ts ← DEPRECATED wrapper over execute.ts (removed in 2.0.0)
 │   └── validation.ts   ← input validation against JSON Schema
 └── utils/
     ├── schema.ts       ← Zod → JSON Schema conversion + schema fingerprinting
@@ -66,9 +67,14 @@ These patterns look like they could be simplified but exist for specific reasons
 
 **Native API detection**: The polyfill checks for native `document.modelContext` (document-only — it does not read `navigator.modelContext`) and skips installation if it exists. Don't remove this check — Chrome is shipping native WebMCP support.
 
-**AbortSignal-only unregistration**: There is no `unregisterTool`. Tools are removed by aborting the `AbortSignal` passed to `registerTool`. `useMcpTool` aborts its controller on cleanup; the registry's abort listener removes the tool. Don't reintroduce an imperative unregister method.
+**AbortSignal-only unregistration**: There is no `unregisterTool`. Tools are removed by aborting the `AbortSignal` passed to `registerTool`. `useMcpTool` aborts its controller on cleanup; the registry's abort listener removes the tool. Don't reintroduce an imperative unregister method. Unregistration does not cancel in-flight executions (Chrome 153.0.8008.0+); they run to completion.
 
-**Single-arg execute/handler**: `descriptor.execute(input)` and the user `handler(args)` take a single argument. There is no `ModelContextClient` second argument. Both execution paths must stay mirrored.
+**Two-arg execute/handler**: `descriptor.execute(input, { signal })` and the user
+`handler(args, ctx)` receive the execution `AbortSignal` as their second argument (Chrome
+153+ shape). There is still no `ModelContextClient`. A missing second argument at runtime
+(Chrome ≤152) is substituted with a never-aborting signal. Both execution paths must stay
+mirrored — they share `runHandler` in `useMcpTool.ts` and `runTool` in
+`polyfill/execute.ts`.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ These patterns look like they could be simplified but exist for specific reasons
 
 **Schema fingerprinting** (`schemaFingerprint` in `utils/schema.ts`, used by `useMcpTool.ts`): useEffect deps use string fingerprints of schemas, not object references, to prevent infinite re-registration loops when schema objects are recreated each render. Don't switch to direct object comparison.
 
-**Dual execution paths**: Tools execute via `execute()` (internal/UI calls) and via the testing shim (external MCP client calls). Both paths update the same reactive state and fire the same callbacks. Changes to one path must be mirrored in the other.
+**Dual execution paths**: Tools execute via `execute()` (internal/UI calls) and via `document.modelContext.executeTool()` (external MCP client calls, native or polyfilled). Both paths update the same reactive state and fire the same callbacks. Changes to one path must be mirrored in the other.
 
 **Ref-wrapped config** (`configRef`, `handlerRef`, etc.): Refs wrap mutable config so the registration useEffect doesn't re-run on every render. These are not missed dependencies — they're intentional stability optimizations.
 
@@ -81,10 +81,10 @@ mirrored — they share `runHandler` in `useMcpTool.ts` and `runTool` in
 - **Framework**: Vitest + React Testing Library + jsdom
 - **Location**: `__tests__/` directories adjacent to source files
 - **StrictMode**: All tests must pass under React StrictMode (double-mount behavior)
-- **Testing shim**: `polyfill/testing-shim.ts` simulates external MCP client calls — use it in tests to verify the full registration → execution → state update cycle
+- **External-call path**: `document.modelContext.getTools()` / `executeTool()` is the consumer API — use it in tests to verify the full registration → execution → state update cycle. `navigator.modelContextTesting` (`polyfill/testing-shim.ts`) delegates to the same engine but is deprecated and is removed in 2.0.0; don't write new tests against it
 - **Coverage areas**: Registration lifecycle, execution state, error handling, input validation, SSR safety, StrictMode compatibility
 
-When adding features, write tests that cover both execution paths (direct `execute()` and testing shim `executeTool()`).
+When adding features, write tests that cover both execution paths (direct `execute()` and `document.modelContext.executeTool()`).
 
 ## Code Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to `webmcp-react` are documented here. The format is based o
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0
+
+Tracks Chrome 152–154 WebMCP changes: execution AbortSignals, the
+`document.modelContext` consumer API, and the removal of
+`navigator.modelContextTesting` from native Chrome.
+
+### Added
+
+- **Handlers receive an execution `AbortSignal`.** Handlers are now called as
+  `handler(args, { signal })`; on Chrome 153.0.8007.0+ the signal aborts when the agent or
+  user cancels the call — pass it to `fetch()` and other cancellable work. On Chrome ≤152
+  (and for bare `execute(args)` calls) the library substitutes a never-aborting signal, so
+  the second argument is always safe to use. The hook's `execute(input?, { signal }?)`
+  accepts a caller signal too. Existing one-argument handlers keep working unchanged.
+- **Polyfill consumer API.** `document.modelContext.getTools()` and
+  `executeTool(tool, inputArguments, { signal }?)`, matching native Chrome:
+  `RegisteredTool.inputSchema` is a deep-copied object (Chrome 154.0.8014.0+ shape),
+  `inputArguments` may be a JSON string or an object, execution failures reject with
+  `UnknownError`, aborts reject with the signal's reason, and unregistering a tool no
+  longer cancels in-flight executions (Chrome 153.0.8008.0+ behavior). The polyfill
+  additionally validates input against `inputSchema` (`OperationError`) — native Chrome
+  does not validate yet.
+- New exported types: `ToolExecuteCallbackOptions`, `ExecuteToolOptions`,
+  `RegisteredTool`, `ModelContextGetToolOptions`.
+
+### Changed
+
+- **Abort is cancellation, not error.** When an execution's signal aborts and the handler
+  rejects, the hook clears `isExecuting` but leaves `state.error` untouched and does not
+  fire `onError`.
+- The testing shim's abort rejections now use the signal's abort reason and its tool
+  failures reject with `UnknownError` (Chrome 152+ parity); its `OperationError` input
+  errors and `NotFoundError` are unchanged.
+
+### Deprecated
+
+- **`navigator.modelContextTesting`.** Native Chrome removed it in 152.0.7940.0. The
+  polyfill's shim now delegates to the same engine as `document.modelContext.executeTool()`
+  and warns once in dev. It will be removed in webmcp-react 2.0.0.
+
 ## 1.0.0
 
 First stable release. From here on, breaking changes to the public API bump the major version.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ function SearchTool() {
     name: "search",
     description: "Search the catalog",
     input: z.object({ query: z.string() }),
-    handler: async ({ query }, { signal }) => ({
+    handler: async ({ query }) => ({
       content: [{ type: "text", text: `Results for: ${query}` }],
     }),
   });

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ function SearchTool() {
     name: "search",
     description: "Search the catalog",
     input: z.object({ query: z.string() }),
-    handler: async ({ query }) => ({
+    handler: async ({ query }, { signal }) => ({
       content: [{ type: "text", text: `Results for: ${query}` }],
     }),
   });
@@ -190,6 +190,17 @@ useMcpTool({
 ### SSR
 
 Works with Next.js, Remix, and any server-rendering framework out of the box. The build includes a `"use client"` banner, so no extra configuration is needed.
+
+## What's new in 1.1.0
+
+- **Handlers get an execution `AbortSignal`**: `handler(args, { signal })`. Chrome 153+
+  aborts it when the agent cancels the call; on older Chrome the library substitutes a
+  never-aborting signal, so `fetch(url, { signal })` is always safe. One-argument handlers
+  keep working.
+- **Consumer API in the polyfill**: `document.modelContext.getTools()` /
+  `executeTool(tool, args, { signal }?)` — the same surface native Chrome 152+ ships.
+- **`navigator.modelContextTesting` is deprecated** (removed from native Chrome in 152;
+  removed from this library in 2.0.0).
 
 ## Breaking changes in 0.2.0
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-This library targets the current [WebMCP](https://github.com/webmachinelearning/webmcp) spec. The registration API lives on `document.modelContext` (an `EventTarget`), and the testing/consumer API lives on `navigator.modelContextTesting`.
+This library targets the current [WebMCP](https://github.com/webmachinelearning/webmcp) spec. Both the registration and consumer APIs live on `document.modelContext` (an `EventTarget`): `registerTool` on the registration side, `getTools()`/`executeTool()` on the consumer side. `navigator.modelContextTesting` is a deprecated wrapper over the same consumer engine.
 
 ## `<WebMCPProvider>`
 
@@ -43,11 +43,11 @@ Registers a tool on `document.modelContext`. Automatically unregisters on unmoun
 | `output`      | `z.ZodObject`                   | Optional Zod schema for outputs (library extension; see below) |
 | `annotations` | `ToolAnnotations`               | Optional behavior hints (`readOnlyHint`, `untrustedContentHint`) |
 | `exposedTo`   | `string[]`                      | Optional list of trustworthy origins this tool is exposed to across frames |
-| `handler`     | `(args) => CallToolResult \| Promise<CallToolResult>` | Tool implementation. Receives a single argument (the parsed input) |
+| `handler`     | `(args, ctx) => CallToolResult \| Promise<CallToolResult>` | Tool implementation. Receives the parsed input and `ctx: { signal: AbortSignal }`; the signal aborts when the agent cancels the execution (Chrome 153+; otherwise a never-aborting substitute) |
 | `onSuccess`   | `(result) => void`              | Optional callback on success                                   |
 | `onError`     | `(error) => void`               | Optional callback on error                                     |
 
-The `handler` takes a **single argument** — the validated input object. There is no second `client` argument.
+The `handler` receives the validated input object and a second `ctx` argument containing the execution `AbortSignal`. Handlers that declare a single parameter keep working.
 
 ### JSON Schema config
 
@@ -80,10 +80,19 @@ const { state, execute, reset } = useMcpTool({ ... });
 | `state.lastResult`     | `CallToolResult \| null`              | Most recent result                 |
 | `state.error`          | `Error \| null`                       | Most recent error                  |
 | `state.executionCount` | `number`                              | Total successful executions        |
-| `execute(input?)`      | `(input?) => Promise<CallToolResult>` | Manually invoke the tool           |
+| `execute(input?, { signal }?)` | `(input?, options?) => Promise<CallToolResult>` | Manually invoke the tool  |
 | `reset()`              | `() => void`                          | Reset state to initial values      |
 
 `execute()` (the UI/direct path) throws if validation or handler logic fails. The agent/testing-shim path returns a `CallToolResult` with `isError: true` instead. Both paths update the same reactive state and fire the same `onSuccess`/`onError` callbacks.
+
+### Cancellation
+
+Each execution gets its own `AbortSignal`, passed to the handler as `ctx.signal`. On
+Chrome 153.0.8007.0+ (and via the polyfill's `executeTool`) it aborts when the caller
+cancels. When an aborted execution's handler rejects, the hook treats it as
+**cancellation**: `isExecuting` clears, but `state.error` stays untouched and `onError`
+does not fire. Unregistering a tool (unmount) does **not** cancel in-flight executions
+(Chrome 153.0.8008.0+ behavior).
 
 ## Results: `CallToolResult`
 
@@ -104,7 +113,20 @@ interface CallToolResult {
 When native WebMCP is unavailable, the provider installs a polyfill that exposes:
 
 - `document.modelContext` — the registration API (an `EventTarget`). `registerTool(tool, options?)` returns a `Promise<undefined>` that **rejects** on invalid input (see below). Unregistration is **AbortSignal-only** — pass `{ signal }` and abort it to remove the tool. There is no `unregisterTool`.
-- `navigator.modelContextTesting` — the consumer/testing API (`listTools()`, `executeTool(name, argsJson, options?)`, `registerToolsChangedCallback(cb)`, `getCrossDocumentScriptToolResult()`). Browser extensions and tests use this to discover and invoke tools.
+- `document.modelContext.getTools(options?)` / `executeTool(tool, inputArguments, options?)`
+  — the consumer API (same shape as native Chrome). `getTools()` resolves sorted, fresh
+  `RegisteredTool` objects whose `inputSchema` is a deep-copied **object**;
+  `executeTool` accepts a JSON string or object input, forwards `options.signal` into the
+  tool's execution signal, rejects `UnknownError` on failure, and — unlike native Chrome —
+  validates input against `inputSchema` (`OperationError`).
+- `navigator.modelContextTesting` — **deprecated** wrapper over the same engine
+  (`listTools()` keeps returning a JSON-string `inputSchema`); removed in 2.0.0.
+
+| Chrome | Behavior this library tracks |
+| --- | --- |
+| ≤152 | `execute(input)` — no tool-side signal (the library substitutes one); `navigator.modelContextTesting` removed in 152.0.7940.0 |
+| 153 | `execute(input, { signal })`; unregistration no longer cancels in-flight executions (153.0.8008.0+) |
+| 154 | `RegisteredTool.inputSchema` is an object (was a JSON string) |
 
 The native API is detected by reading `document.modelContext` only; the polyfill marks itself with `__isWebMCPPolyfill` so native support short-circuits installation.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmcp-react",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "React hooks for exposing your app's functionality as WebMCP tools - transport-agnostic, SSR-safe, Strict Mode safe, W3C spec-aligned",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/skills/webmcp-add-tool/SKILL.md
+++ b/skills/webmcp-add-tool/SKILL.md
@@ -33,9 +33,9 @@ export function MyTool() {
       // Define each input field with .describe() for AI context
       query: z.string().describe("The search query"),
     }),
-    handler: async ({ query }) => {
-      // Implement tool logic here
-      const result = await doSomething(query);
+    handler: async ({ query }, { signal }) => {
+      // signal aborts if the agent cancels — forward it to cancellable work
+      const result = await doSomething(query, { signal });
       return {
         content: [{ type: "text", text: JSON.stringify(result) }],
       };

--- a/skills/webmcp-setup/SKILL.md
+++ b/skills/webmcp-setup/SKILL.md
@@ -91,9 +91,11 @@ export function GreetTool() {
     input: z.object({
       name: z.string().describe("The name to greet"),
     }),
-    handler: async ({ name }) => ({
-      content: [{ type: "text", text: `Hello, ${name}!` }],
-    }),
+    handler: async ({ name }, { signal }) => {
+      // signal aborts if the agent cancels — forward it to cancellable work
+      const res = await fetch(`/api/greet?name=${encodeURIComponent(name)}`, { signal });
+      return { content: [{ type: "text", text: await res.text() }] };
+    },
   });
   return null;
 }

--- a/src/hooks/__tests__/useMcpTool.test.tsx
+++ b/src/hooks/__tests__/useMcpTool.test.tsx
@@ -632,7 +632,7 @@ describe("Strict Mode safety", () => {
               name: "greet",
               description: "Say hello",
               input: z.object({ name: z.string() }),
-              handler: async ({ name }) => makeResult(`hello ${name}`),
+              handler: async ({ name }: Record<string, unknown>) => makeResult(`hello ${name}`),
             }}
           />
         </WebMCPProvider>
@@ -978,7 +978,7 @@ describe("MCP integration", () => {
           name: "greet",
           description: "Say hello",
           input: z.object({ name: z.string() }),
-          handler: async ({ name }) => makeResult(`hello ${name}`),
+          handler: async ({ name }: Record<string, unknown>) => makeResult(`hello ${name}`),
         }}
       />,
     );
@@ -1628,10 +1628,11 @@ describe("execution signal", () => {
     );
     await waitForRegistration();
     const controller = new AbortController();
+    const exec = executeRef.current as ExecuteFn;
     let rejected: unknown = null;
     let promise!: Promise<CallToolResult>;
     act(() => {
-      promise = executeRef.current!({}, { signal: controller.signal });
+      promise = exec({}, { signal: controller.signal });
       promise.catch((e: unknown) => {
         rejected = e;
       });
@@ -1729,8 +1730,9 @@ describe("execution signal", () => {
     );
     await waitForRegistration();
     const controller = new AbortController(); // present but never aborted
+    const exec = executeRef.current as ExecuteFn;
     await act(async () => {
-      await executeRef.current!({}, { signal: controller.signal }).catch(() => {});
+      await exec({}, { signal: controller.signal }).catch(() => {});
     });
     expect(onError).toHaveBeenCalledTimes(1);
     expect(getByTestId("error").textContent).toBe("genuine failure");

--- a/src/hooks/__tests__/useMcpTool.test.tsx
+++ b/src/hooks/__tests__/useMcpTool.test.tsx
@@ -6,7 +6,12 @@ import { z } from "zod";
 import * as z3 from "zod/v3";
 import { _resetPolyfillConsumerCount, WebMCPProvider } from "../../context";
 import { cleanupPolyfill } from "../../polyfill";
-import type { CallToolResult, McpToolConfigJsonSchema, McpToolConfigZod } from "../../types";
+import type {
+  CallToolResult,
+  McpToolConfigJsonSchema,
+  McpToolConfigZod,
+  ToolDescriptor,
+} from "../../types";
 import { _resetWarnings } from "../../utils/warn";
 import { _resetToolOwners, useMcpTool } from "../useMcpTool";
 
@@ -1532,5 +1537,202 @@ describe("native registerTool compatibility (void return / sync throw)", () => {
     expect(onError).not.toHaveBeenCalled();
     const last = onState.mock.calls.at(-1)?.[0];
     expect(last?.error).toBeNull();
+  });
+});
+
+// ─── Execution signal (Chrome 153+ shape) ────────────────────────
+
+describe("execution signal", () => {
+  function installFakeNative() {
+    const captured: ToolDescriptor[] = [];
+    const fake = {
+      registerTool: (tool: ToolDescriptor) => {
+        captured.push(tool);
+        return Promise.resolve(undefined);
+      },
+    };
+    Object.defineProperty(document, "modelContext", { value: fake, configurable: true });
+    return {
+      captured,
+      uninstall: () => {
+        delete (document as { modelContext?: unknown }).modelContext;
+      },
+    };
+  }
+
+  it("direct execute() passes a non-aborted AbortSignal to the handler", async () => {
+    const seen: Array<{ signal: AbortSignal }> = [];
+    const executeRef = { current: null as ExecuteFn | null };
+    renderWithProvider(
+      <ToolComponent
+        config={{
+          name: "sig_direct",
+          description: "d",
+          handler: async (_args, ctx) => {
+            seen.push(ctx);
+            return OK_RESULT;
+          },
+        }}
+        onExecuteRef={executeRef}
+      />,
+    );
+    await waitForRegistration();
+    await act(async () => {
+      await executeRef.current?.();
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].signal).toBeInstanceOf(AbortSignal);
+    expect(seen[0].signal.aborted).toBe(false);
+  });
+
+  it("direct execute() forwards a caller-provided signal", async () => {
+    let received: AbortSignal | undefined;
+    const executeRef = { current: null as ExecuteFn | null };
+    renderWithProvider(
+      <ToolComponent
+        config={{
+          name: "sig_forward",
+          description: "d",
+          handler: async (_args, { signal }) => {
+            received = signal;
+            return OK_RESULT;
+          },
+        }}
+        onExecuteRef={executeRef}
+      />,
+    );
+    await waitForRegistration();
+    const controller = new AbortController();
+    await act(async () => {
+      await executeRef.current?.({}, { signal: controller.signal });
+    });
+    expect(received).toBe(controller.signal);
+  });
+
+  it("aborted execution is cancellation: rethrows but no state.error, no onError", async () => {
+    const onError = vi.fn();
+    const executeRef = { current: null as ExecuteFn | null };
+    const { getByTestId } = renderWithProvider(
+      <ToolComponent
+        config={{
+          name: "sig_cancel",
+          description: "d",
+          onError,
+          handler: (_args, { signal }) =>
+            new Promise<CallToolResult>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+            }),
+        }}
+        onExecuteRef={executeRef}
+      />,
+    );
+    await waitForRegistration();
+    const controller = new AbortController();
+    let rejected: unknown = null;
+    let promise!: Promise<CallToolResult>;
+    act(() => {
+      promise = executeRef.current!({}, { signal: controller.signal });
+      promise.catch((e: unknown) => {
+        rejected = e;
+      });
+    });
+    await act(async () => {
+      controller.abort(new DOMException("user cancelled", "AbortError"));
+      await promise.catch(() => {});
+    });
+    expect((rejected as { name?: string })?.name).toBe("AbortError");
+    expect(onError).not.toHaveBeenCalled();
+    expect(getByTestId("error").textContent).toBe("none");
+    expect(getByTestId("executing").textContent).toBe("no");
+  });
+
+  it("descriptor execute forwards Chrome's signal and treats abort as cancellation", async () => {
+    const { captured, uninstall } = installFakeNative();
+    try {
+      const onError = vi.fn();
+      const { getByTestId } = renderWithProvider(
+        <ToolComponent
+          config={{
+            name: "sig_native",
+            description: "d",
+            onError,
+            handler: (_args, { signal }) =>
+              new Promise<CallToolResult>((_resolve, reject) => {
+                signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+              }),
+          }}
+        />,
+      );
+      await waitFor(() => expect(captured.length).toBeGreaterThan(0));
+      const controller = new AbortController();
+      let result!: Promise<CallToolResult>;
+      act(() => {
+        result = Promise.resolve(captured[0].execute({}, { signal: controller.signal }));
+      });
+      let settled: CallToolResult | undefined;
+      await act(async () => {
+        controller.abort();
+        settled = await result;
+      });
+      // The agent path resolves with an isError result rather than rejecting.
+      expect(settled?.isError).toBe(true);
+      expect(onError).not.toHaveBeenCalled();
+      expect(getByTestId("error").textContent).toBe("none");
+    } finally {
+      uninstall();
+    }
+  });
+
+  it("bare descriptor execute (Chrome <=152 shape) still provides a real signal", async () => {
+    const { captured, uninstall } = installFakeNative();
+    try {
+      let ctxSeen: { signal: AbortSignal } | undefined;
+      renderWithProvider(
+        <ToolComponent
+          config={{
+            name: "sig_bare",
+            description: "d",
+            handler: async (_args, ctx) => {
+              ctxSeen = ctx;
+              return OK_RESULT;
+            },
+          }}
+        />,
+      );
+      await waitFor(() => expect(captured.length).toBeGreaterThan(0));
+      await act(async () => {
+        // Chrome <=152 calls execute with a single argument.
+        await (captured[0].execute as unknown as (input: Record<string, unknown>) => unknown)({});
+      });
+      expect(ctxSeen?.signal).toBeInstanceOf(AbortSignal);
+      expect(ctxSeen?.signal.aborted).toBe(false);
+    } finally {
+      uninstall();
+    }
+  });
+
+  it("non-abort failures still set state.error and fire onError", async () => {
+    const onError = vi.fn();
+    const executeRef = { current: null as ExecuteFn | null };
+    const { getByTestId } = renderWithProvider(
+      <ToolComponent
+        config={{
+          name: "sig_realfail",
+          description: "d",
+          onError,
+          handler: async () => {
+            throw new Error("genuine failure");
+          },
+        }}
+        onExecuteRef={executeRef}
+      />,
+    );
+    await waitForRegistration();
+    const controller = new AbortController(); // present but never aborted
+    await act(async () => {
+      await executeRef.current!({}, { signal: controller.signal }).catch(() => {});
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(getByTestId("error").textContent).toBe("genuine failure");
   });
 });

--- a/src/hooks/useMcpTool.ts
+++ b/src/hooks/useMcpTool.ts
@@ -116,7 +116,9 @@ export function useMcpTool(config: McpToolConfigZod | McpToolConfigJsonSchema): 
         validatedInput = parseZodInput((currentConfig as McpToolConfigZod).input, validatedInput);
       }
 
-      const result = await handlerRef.current(validatedInput as Record<string, unknown>);
+      const result = await handlerRef.current(validatedInput as Record<string, unknown>, {
+        signal: new AbortController().signal,
+      });
 
       if (isMountedRef.current) {
         inFlightCountRef.current--;
@@ -200,7 +202,9 @@ export function useMcpTool(config: McpToolConfigZod | McpToolConfigJsonSchema): 
             validatedArgs = parseZodInput((currentConfig as McpToolConfigZod).input, args);
           }
 
-          const result = await handlerRef.current(validatedArgs as Record<string, unknown>);
+          const result = await handlerRef.current(validatedArgs as Record<string, unknown>, {
+            signal: new AbortController().signal,
+          });
 
           if (isMountedRef.current) {
             inFlightCountRef.current--;

--- a/src/hooks/useMcpTool.ts
+++ b/src/hooks/useMcpTool.ts
@@ -2,9 +2,11 @@ import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { MISSING_PROVIDER, WebMCPContext } from "../context";
 import type {
   CallToolResult,
+  ExecuteToolOptions,
   McpToolConfigJsonSchema,
   McpToolConfigZod,
   ToolDescriptor,
+  ToolExecuteCallbackOptions,
   ToolExecutionState,
   UseMcpToolReturn,
   ZodObjectSchema,
@@ -103,55 +105,78 @@ export function useMcpTool(config: McpToolConfigZod | McpToolConfigJsonSchema): 
     };
   }, []);
 
-  const execute = useCallback(async (input?: Record<string, unknown>): Promise<CallToolResult> => {
-    inFlightCountRef.current++;
-    setState((prev) => ({ ...prev, isExecuting: true, error: null }));
-
-    try {
-      let validatedInput: Record<string, unknown> = input ?? {};
-      const currentConfig = configRef.current;
-      const currentIsZod = "input" in currentConfig && isZodObjectSchema(currentConfig.input);
-
-      if (currentIsZod) {
-        validatedInput = parseZodInput((currentConfig as McpToolConfigZod).input, validatedInput);
-      }
-
-      const result = await handlerRef.current(validatedInput as Record<string, unknown>, {
-        signal: new AbortController().signal,
-      });
-
+  const runHandler = useCallback(
+    async (
+      input: Record<string, unknown>,
+      signal: AbortSignal,
+      opts: { throwOnError: boolean },
+    ): Promise<CallToolResult> => {
+      inFlightCountRef.current++;
       if (isMountedRef.current) {
-        inFlightCountRef.current--;
-        setState((prev) => ({
-          isExecuting: inFlightCountRef.current > 0,
-          lastResult: result,
-          error: null,
-          executionCount: prev.executionCount + 1,
-        }));
-      } else {
-        inFlightCountRef.current--;
+        setState((prev) => ({ ...prev, isExecuting: true, error: null }));
       }
 
-      onSuccessRef.current?.(result);
-      return result;
-    } catch (thrown) {
-      const error = thrown instanceof Error ? thrown : new Error(String(thrown));
+      try {
+        let validatedInput = input;
+        const currentConfig = configRef.current;
+        const currentIsZod = "input" in currentConfig && isZodObjectSchema(currentConfig.input);
 
-      if (isMountedRef.current) {
+        if (currentIsZod) {
+          validatedInput = parseZodInput((currentConfig as McpToolConfigZod).input, input);
+        }
+
+        const result = await handlerRef.current(validatedInput, { signal });
+
         inFlightCountRef.current--;
-        setState((prev) => ({
-          ...prev,
-          isExecuting: inFlightCountRef.current > 0,
-          error,
-        }));
-      } else {
+        if (isMountedRef.current) {
+          setState((prev) => ({
+            isExecuting: inFlightCountRef.current > 0,
+            lastResult: result,
+            error: null,
+            executionCount: prev.executionCount + 1,
+          }));
+        }
+
+        onSuccessRef.current?.(result);
+        return result;
+      } catch (thrown) {
+        const error = normalizeError(thrown);
         inFlightCountRef.current--;
+
+        if (signal.aborted) {
+          // Cancellation, not error: the agent/user aborted this execution.
+          // Leave error/lastResult untouched and skip onError.
+          if (isMountedRef.current) {
+            setState((prev) => ({ ...prev, isExecuting: inFlightCountRef.current > 0 }));
+          }
+        } else {
+          if (isMountedRef.current) {
+            setState((prev) => ({
+              ...prev,
+              isExecuting: inFlightCountRef.current > 0,
+              error,
+            }));
+          }
+          onErrorRef.current?.(error);
+        }
+
+        if (opts.throwOnError) throw error;
+        return {
+          content: [{ type: "text", text: `Error: ${error.message}` }],
+          isError: true,
+        };
       }
+    },
+    [],
+  );
 
-      onErrorRef.current?.(error);
-      throw error;
-    }
-  }, []);
+  const execute = useCallback(
+    (input?: Record<string, unknown>, options?: ExecuteToolOptions): Promise<CallToolResult> =>
+      runHandler(input ?? {}, options?.signal ?? new AbortController().signal, {
+        throwOnError: true,
+      }),
+    [runHandler],
+  );
 
   const reset = useCallback(() => {
     setState(INITIAL_STATE);
@@ -187,61 +212,10 @@ export function useMcpTool(config: McpToolConfigZod | McpToolConfigJsonSchema): 
       ...(resolvedInputSchema && { inputSchema: resolvedInputSchema }),
       ...(resolvedOutputSchema && { outputSchema: resolvedOutputSchema }),
       ...(cfg.annotations && { annotations: cfg.annotations }),
-      execute: async (args: Record<string, unknown>): Promise<CallToolResult> => {
-        inFlightCountRef.current++;
-        if (isMountedRef.current) {
-          setState((prev) => ({ ...prev, isExecuting: true, error: null }));
-        }
-
-        try {
-          let validatedArgs = args;
-          const currentConfig = configRef.current;
-          const currentIsZod = "input" in currentConfig && isZodObjectSchema(currentConfig.input);
-
-          if (currentIsZod) {
-            validatedArgs = parseZodInput((currentConfig as McpToolConfigZod).input, args);
-          }
-
-          const result = await handlerRef.current(validatedArgs as Record<string, unknown>, {
-            signal: new AbortController().signal,
-          });
-
-          if (isMountedRef.current) {
-            inFlightCountRef.current--;
-            setState((prev) => ({
-              isExecuting: inFlightCountRef.current > 0,
-              lastResult: result,
-              error: null,
-              executionCount: prev.executionCount + 1,
-            }));
-          } else {
-            inFlightCountRef.current--;
-          }
-
-          onSuccessRef.current?.(result);
-          return result;
-        } catch (thrown) {
-          const error = thrown instanceof Error ? thrown : new Error(String(thrown));
-
-          if (isMountedRef.current) {
-            inFlightCountRef.current--;
-            setState((prev) => ({
-              ...prev,
-              isExecuting: inFlightCountRef.current > 0,
-              error,
-            }));
-          } else {
-            inFlightCountRef.current--;
-          }
-
-          onErrorRef.current?.(error);
-
-          return {
-            content: [{ type: "text", text: `Error: ${error.message}` }],
-            isError: true,
-          };
-        }
-      },
+      execute: (args: Record<string, unknown>, options?: ToolExecuteCallbackOptions) =>
+        runHandler(args, options?.signal ?? new AbortController().signal, {
+          throwOnError: false,
+        }),
     };
 
     const controller = new AbortController();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,14 @@ export { useWebMCPStatus, WebMCPProvider } from "./context";
 export { useMcpTool } from "./hooks/useMcpTool";
 export type {
   CallToolResult,
+  ExecuteToolOptions,
   McpToolConfigJsonSchema,
   McpToolConfigZod,
+  ModelContextGetToolOptions,
+  RegisteredTool,
   RegisterToolOptions,
   ToolAnnotations,
+  ToolExecuteCallbackOptions,
   ToolExecutionState,
   UseMcpToolReturn,
   WebMCPProviderProps,

--- a/src/polyfill/__tests__/consumer-api.test.ts
+++ b/src/polyfill/__tests__/consumer-api.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
-import type { CallToolResult, ModelContext, RegisteredTool, ToolDescriptor } from "../../types";
+import type {
+  CallToolResult,
+  InputSchema,
+  InputSchemaProperty,
+  ModelContext,
+  RegisteredTool,
+  ToolDescriptor,
+} from "../../types";
 import { cleanupPolyfill, installPolyfill } from "..";
 
 function makeTool(overrides?: Partial<ToolDescriptor>): ToolDescriptor {
@@ -19,6 +26,9 @@ function makeTool(overrides?: Partial<ToolDescriptor>): ToolDescriptor {
 // The polyfill always implements getTools/executeTool; narrow once here.
 type InstalledModelContext = ModelContext &
   Required<Pick<ModelContext, "getTools" | "executeTool">>;
+
+// The schema shape makeTool() registers, down to the nested "query" property.
+type SchemaWithQuery = InputSchema & { properties: { query: InputSchemaProperty } };
 
 function mc(): InstalledModelContext {
   const m = document.modelContext;
@@ -48,9 +58,14 @@ describe("document.modelContext.getTools (polyfill)", () => {
     installPolyfill();
     await mc().registerTool(makeTool());
     const [first] = await mc().getTools();
-    (first.inputSchema as Record<string, unknown>).type = "mutated";
+    const firstSchema = first.inputSchema as SchemaWithQuery;
+    // Mutate a nested node; a top-level mutation can't tell deep from shallow.
+    firstSchema.type = "mutated";
+    firstSchema.properties.query.type = "mutated";
     const [second] = await mc().getTools();
-    expect((second.inputSchema as Record<string, unknown>).type).toBe("object");
+    const secondSchema = second.inputSchema as SchemaWithQuery;
+    expect(secondSchema.type).toBe("object");
+    expect(secondSchema.properties.query.type).toBe("string");
   });
 
   it("returns fresh objects on every call", async () => {
@@ -135,10 +150,12 @@ describe("document.modelContext.executeTool (polyfill)", () => {
     const registration = new AbortController();
     let resolveTool!: (r: CallToolResult) => void;
     let toolSignalAborted = false;
+    let started = false;
     await mc().registerTool(
       makeTool({
         inputSchema: undefined,
         execute: (_input, { signal }) => {
+          started = true;
           signal.addEventListener("abort", () => {
             toolSignalAborted = true;
           });
@@ -151,7 +168,8 @@ describe("document.modelContext.executeTool (polyfill)", () => {
     );
     const [tool] = await mc().getTools();
     const pending = mc().executeTool(tool, "{}");
-    await Promise.resolve(); // let execute start
+    await Promise.resolve(); // flush the microtask that starts execute
+    expect(started).toBe(true);
     registration.abort(); // unregister mid-flight (Chrome 153.0.8008+ behavior)
     resolveTool({ content: [{ type: "text", text: "late-ok" }] });
     const raw = await pending;

--- a/src/polyfill/__tests__/consumer-api.test.ts
+++ b/src/polyfill/__tests__/consumer-api.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { CallToolResult, ModelContext, RegisteredTool, ToolDescriptor } from "../../types";
+import { cleanupPolyfill, installPolyfill } from "..";
+
+function makeTool(overrides?: Partial<ToolDescriptor>): ToolDescriptor {
+  return {
+    name: "consumer_tool",
+    description: "consumer test tool",
+    inputSchema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+    execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    ...overrides,
+  };
+}
+
+// The polyfill always implements getTools/executeTool; narrow once here.
+type InstalledModelContext = ModelContext &
+  Required<Pick<ModelContext, "getTools" | "executeTool">>;
+
+function mc(): InstalledModelContext {
+  const m = document.modelContext;
+  if (!m) throw new Error("polyfill not installed");
+  return m as InstalledModelContext;
+}
+
+afterEach(() => {
+  cleanupPolyfill();
+});
+
+describe("document.modelContext.getTools (polyfill)", () => {
+  it("returns registered tools sorted by name with object inputSchema and defaults", async () => {
+    installPolyfill();
+    await mc().registerTool(makeTool({ name: "b_tool" }));
+    await mc().registerTool(makeTool({ name: "a_tool" }));
+    const tools = await mc().getTools();
+    expect(tools.map((t) => t.name)).toEqual(["a_tool", "b_tool"]);
+    expect(typeof tools[0].inputSchema).toBe("object");
+    expect(tools[0].title).toBe("");
+    expect(tools[0].description).toBe("consumer test tool");
+    expect(tools[0].origin).toBe(location.origin);
+    expect(tools[0].window).toBe(window);
+  });
+
+  it("returns a deep copy of inputSchema (mutation does not leak back)", async () => {
+    installPolyfill();
+    await mc().registerTool(makeTool());
+    const [first] = await mc().getTools();
+    (first.inputSchema as Record<string, unknown>).type = "mutated";
+    const [second] = await mc().getTools();
+    expect((second.inputSchema as Record<string, unknown>).type).toBe("object");
+  });
+
+  it("returns fresh objects on every call", async () => {
+    installPolyfill();
+    await mc().registerTool(makeTool());
+    const [a] = await mc().getTools();
+    const [b] = await mc().getTools();
+    expect(a).not.toBe(b);
+  });
+
+  it("preserves title and annotations when registered", async () => {
+    installPolyfill();
+    await mc().registerTool(makeTool({ title: "Nice Tool", annotations: { readOnlyHint: true } }));
+    const [tool] = await mc().getTools();
+    expect(tool.title).toBe("Nice Tool");
+    expect(tool.annotations).toEqual({ readOnlyHint: true });
+  });
+
+  it("rejects SecurityError for an untrustworthy fromOrigins entry", async () => {
+    installPolyfill();
+    await expect(mc().getTools({ fromOrigins: ["http://evil.example"] })).rejects.toThrow(
+      expect.objectContaining({ name: "SecurityError" }),
+    );
+  });
+});
+
+describe("document.modelContext.executeTool (polyfill)", () => {
+  it("executes by RegisteredTool and resolves the JSON result", async () => {
+    installPolyfill();
+    await mc().registerTool(makeTool());
+    const [tool] = await mc().getTools();
+    const raw = await mc().executeTool(tool, '{"query":"x"}');
+    expect(JSON.parse(raw as string)).toEqual({ content: [{ type: "text", text: "ok" }] });
+  });
+
+  it("accepts an object inputArguments", async () => {
+    installPolyfill();
+    await mc().registerTool(makeTool());
+    const [tool] = await mc().getTools();
+    const raw = await mc().executeTool(tool, { query: "x" });
+    expect(JSON.parse(raw as string)).toEqual({ content: [{ type: "text", text: "ok" }] });
+  });
+
+  it("rejects UnknownError for a stale/unregistered tool", async () => {
+    installPolyfill();
+    const stale: RegisteredTool = { name: "ghost", description: "gone" };
+    await expect(mc().executeTool(stale, "{}")).rejects.toThrow(
+      expect.objectContaining({ name: "UnknownError" }),
+    );
+  });
+
+  it("forwards the caller signal: tool-side signal aborts, caller gets its reason", async () => {
+    installPolyfill();
+    let toolAborted = false;
+    await mc().registerTool(
+      makeTool({
+        inputSchema: undefined,
+        execute: (_input, { signal }) =>
+          new Promise<CallToolResult>((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                toolAborted = true;
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          }),
+      }),
+    );
+    const [tool] = await mc().getTools();
+    const controller = new AbortController();
+    const reason = new Error("cancel it");
+    const promise = mc().executeTool(tool, "{}", { signal: controller.signal });
+    controller.abort(reason);
+    await expect(promise).rejects.toBe(reason);
+    expect(toolAborted).toBe(true);
+  });
+
+  it("keeps an in-flight execution alive when the tool is unregistered mid-flight", async () => {
+    installPolyfill();
+    const registration = new AbortController();
+    let resolveTool!: (r: CallToolResult) => void;
+    let toolSignalAborted = false;
+    await mc().registerTool(
+      makeTool({
+        inputSchema: undefined,
+        execute: (_input, { signal }) => {
+          signal.addEventListener("abort", () => {
+            toolSignalAborted = true;
+          });
+          return new Promise<CallToolResult>((resolve) => {
+            resolveTool = resolve;
+          });
+        },
+      }),
+      { signal: registration.signal },
+    );
+    const [tool] = await mc().getTools();
+    const pending = mc().executeTool(tool, "{}");
+    await Promise.resolve(); // let execute start
+    registration.abort(); // unregister mid-flight (Chrome 153.0.8008+ behavior)
+    resolveTool({ content: [{ type: "text", text: "late-ok" }] });
+    const raw = await pending;
+    expect(JSON.parse(raw as string).content[0].text).toBe("late-ok");
+    expect(toolSignalAborted).toBe(false);
+    expect((await mc().getTools()).map((t) => t.name)).not.toContain("consumer_tool");
+  });
+});

--- a/src/polyfill/__tests__/execute.test.ts
+++ b/src/polyfill/__tests__/execute.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CallToolResult, ToolDescriptor } from "../../types";
+import { runTool } from "../execute";
+
+function makeTool(overrides?: Partial<ToolDescriptor>): ToolDescriptor {
+  return {
+    name: "engine_tool",
+    description: "engine test tool",
+    inputSchema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+    execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    ...overrides,
+  };
+}
+
+const OK: CallToolResult = { content: [{ type: "text", text: "ok" }] };
+
+describe("runTool", () => {
+  it("passes parsed args and a fresh non-aborted signal to execute", async () => {
+    const execute = vi.fn(
+      async (_input: Record<string, unknown>, options: { signal: AbortSignal }) => {
+        expect(options.signal).toBeInstanceOf(AbortSignal);
+        expect(options.signal.aborted).toBe(false);
+        return OK;
+      },
+    );
+    await runTool(makeTool({ execute }), '{"query":"hi"}');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0][0]).toEqual({ query: "hi" });
+  });
+
+  it("accepts an object input without re-parsing", async () => {
+    const execute = vi.fn(async () => OK);
+    await runTool(makeTool({ execute }), { query: "hi" });
+    expect(execute.mock.calls[0][0]).toEqual({ query: "hi" });
+  });
+
+  it("gives each execution an independent signal", async () => {
+    const signals: AbortSignal[] = [];
+    const tool = makeTool({
+      inputSchema: undefined,
+      execute: async (_i, { signal }) => {
+        signals.push(signal);
+        return OK;
+      },
+    });
+    await runTool(tool, "{}");
+    await runTool(tool, "{}");
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+
+  it("serializes object results to JSON", async () => {
+    const raw = await runTool(makeTool(), '{"query":"x"}');
+    expect(JSON.parse(raw)).toEqual(OK);
+  });
+
+  it("stringifies primitive results and maps empty string to 'Operation succeeded'", async () => {
+    // Non-CallToolResult returns exercise native-parity serialization.
+    const num = makeTool({
+      inputSchema: undefined,
+      execute: () => 42 as unknown as CallToolResult,
+    });
+    expect(await runTool(num, "{}")).toBe("42");
+    const empty = makeTool({
+      inputSchema: undefined,
+      execute: () => "" as unknown as CallToolResult,
+    });
+    expect(await runTool(empty, "{}")).toBe("Operation succeeded");
+  });
+
+  it("rejects UnknownError for a non-serializable (circular) result", async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const tool = makeTool({
+      inputSchema: undefined,
+      execute: () => circular as unknown as CallToolResult,
+    });
+    await expect(runTool(tool, "{}")).rejects.toThrow(
+      expect.objectContaining({ name: "UnknownError" }),
+    );
+  });
+
+  it("rejects UnknownError on invalid JSON string input", async () => {
+    await expect(runTool(makeTool(), "not json")).rejects.toThrow(
+      expect.objectContaining({ name: "UnknownError" }),
+    );
+  });
+
+  it("rejects UnknownError on non-object JSON input", async () => {
+    await expect(runTool(makeTool(), '"a string"')).rejects.toThrow(
+      expect.objectContaining({ name: "UnknownError" }),
+    );
+  });
+
+  it("rejects OperationError on schema violation (polyfill-only validation)", async () => {
+    await expect(runTool(makeTool(), "{}")).rejects.toThrow(
+      expect.objectContaining({
+        name: "OperationError",
+        message: 'Missing required field: "query"',
+      }),
+    );
+  });
+
+  it("rejects with the exact reason for a pre-aborted caller signal", async () => {
+    const reason = new DOMException("pre-cancelled", "AbortError");
+    await expect(runTool(makeTool(), '{"query":"x"}', AbortSignal.abort(reason))).rejects.toBe(
+      reason,
+    );
+  });
+
+  it("mid-flight abort: caller gets caller's reason, tool gets a generic AbortError", async () => {
+    const controller = new AbortController();
+    let toolReason: unknown;
+    const tool = makeTool({
+      inputSchema: undefined,
+      execute: (_i, { signal }) =>
+        new Promise<CallToolResult>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              toolReason = signal.reason;
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        }),
+    });
+    const callerReason = new Error("custom cancellation reason");
+    const promise = runTool(tool, "{}", controller.signal);
+    controller.abort(callerReason);
+    await expect(promise).rejects.toBe(callerReason);
+    // Chrome 153: the tool-side signal always aborts with a generic AbortError,
+    // never the caller's custom reason.
+    expect((toolReason as { name?: string })?.name).toBe("AbortError");
+    expect(toolReason).not.toBe(callerReason);
+  });
+
+  it("ignores late settlement after abort (no unhandled rejection, result stays rejected)", async () => {
+    const controller = new AbortController();
+    let resolveTool!: (r: CallToolResult) => void;
+    const tool = makeTool({
+      inputSchema: undefined,
+      execute: () =>
+        new Promise<CallToolResult>((resolve) => {
+          resolveTool = resolve;
+        }),
+    });
+    const promise = runTool(tool, "{}", controller.signal);
+    controller.abort();
+    await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
+    resolveTool(OK); // late — must be silently ignored
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it("swallows late rejection after abort (no unhandled rejection)", async () => {
+    const controller = new AbortController();
+    let rejectTool!: (e: unknown) => void;
+    const tool = makeTool({
+      inputSchema: undefined,
+      execute: () =>
+        new Promise<CallToolResult>((_resolve, reject) => {
+          rejectTool = reject;
+        }),
+    });
+    const promise = runTool(tool, "{}", controller.signal);
+    controller.abort();
+    await expect(promise).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
+    rejectTool(new Error("late failure"));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it("rejects UnknownError (message preserved) when the tool fails without abort", async () => {
+    const tool = makeTool({
+      inputSchema: undefined,
+      execute: () => {
+        throw new Error("handler broke");
+      },
+    });
+    await expect(runTool(tool, "{}")).rejects.toThrow(
+      expect.objectContaining({ name: "UnknownError" }),
+    );
+    await expect(runTool(tool, "{}")).rejects.toThrow("handler broke");
+  });
+});

--- a/src/polyfill/__tests__/testing-shim.test.ts
+++ b/src/polyfill/__tests__/testing-shim.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CallToolResult, ToolDescriptor } from "../../types";
+import { _resetWarnings } from "../../utils/warn";
 import { createRegistry } from "../registry";
 import { createTestingShim } from "../testing-shim";
 
@@ -63,20 +64,22 @@ describe("createTestingShim", () => {
       expect(handler.mock.calls[0][0]).toEqual({ query: "hello" });
     });
 
-    it("calls execute with a single input argument (no client)", async () => {
+    it("calls execute with input and an options object carrying an AbortSignal", async () => {
+      // Chrome 153+ shape: execute(input, { signal }).
       const registry = createRegistry();
       const shim = createTestingShim(registry);
-      let argCount = -1;
+      let args: unknown[] = [];
       await registry.registerTool({
         name: "arity_tool",
         description: "checks arity",
-        execute: (...args: unknown[]) => {
-          argCount = args.length;
+        execute: (...a: unknown[]) => {
+          args = a;
           return { content: [{ type: "text", text: "ok" }] };
         },
       });
       await shim.executeTool("arity_tool", "{}");
-      expect(argCount).toBe(1);
+      expect(args).toHaveLength(2);
+      expect((args[1] as { signal: AbortSignal }).signal).toBeInstanceOf(AbortSignal);
     });
 
     it("returns stringified CallToolResult", async () => {
@@ -185,7 +188,8 @@ describe("createTestingShim", () => {
       ).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
     });
 
-    it("does not produce unhandled rejection when handler aborts then throws", async () => {
+    it("rejects with the abort reason (not the handler error) when handler aborts then throws", async () => {
+      // Chrome 152+: once aborted, the caller sees the abort reason.
       const controller = new AbortController();
       const { shim } = setup([
         makeTool({
@@ -198,7 +202,7 @@ describe("createTestingShim", () => {
 
       await expect(
         shim.executeTool("test_tool", '{"query":"x"}', { signal: controller.signal }),
-      ).rejects.toThrow("handler threw after aborting");
+      ).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
     });
 
     it("rejects immediately with AbortError for pre-aborted signal", async () => {
@@ -209,6 +213,19 @@ describe("createTestingShim", () => {
       await expect(
         shim.executeTool("test_tool", '{"query":"x"}', { signal: controller.signal }),
       ).rejects.toThrow(expect.objectContaining({ name: "AbortError" }));
+    });
+
+    it("warns once about deprecation", async () => {
+      _resetWarnings();
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { shim } = setup();
+      await shim.executeTool("test_tool", '{"query":"x"}');
+      shim.listTools();
+      const deprecationWarns = spy.mock.calls.filter(
+        (c) => typeof c[0] === "string" && c[0].includes("modelContextTesting is deprecated"),
+      );
+      expect(deprecationWarns).toHaveLength(1);
+      spy.mockRestore();
     });
   });
 

--- a/src/polyfill/execute.ts
+++ b/src/polyfill/execute.ts
@@ -1,0 +1,97 @@
+import type { ToolDescriptor } from "../types";
+import { validateArgs } from "./validation";
+
+function serializeResult(result: unknown): string {
+  const text =
+    typeof result === "object" && result !== null
+      ? JSON.stringify(result) // throws on cycles — handled by the caller
+      : String(result);
+  return text === "" ? "Operation succeeded" : text;
+}
+
+/**
+ * Execute a registered tool the way native Chrome does (152–154 behavior):
+ * JSON-string or object input, per-execution AbortSignal forwarded to the
+ * tool, caller abort rejects with the caller signal's reason while the
+ * tool-side signal aborts with a generic AbortError, late settlement after
+ * abort is ignored, and results serialize to a string (objects via JSON,
+ * primitives via String, empty string → "Operation succeeded").
+ *
+ * Deviation from native: input is validated against the tool's inputSchema
+ * (OperationError) — Chrome does not validate yet (spec issue #92).
+ */
+export function runTool(
+  tool: ToolDescriptor,
+  inputArguments: string | object,
+  callerSignal?: AbortSignal,
+): Promise<string> {
+  if (callerSignal?.aborted) {
+    return Promise.reject(callerSignal.reason);
+  }
+
+  let parsed: unknown;
+  if (typeof inputArguments === "string") {
+    try {
+      parsed = JSON.parse(inputArguments);
+    } catch {
+      return Promise.reject(new DOMException("Failed to parse input arguments", "UnknownError"));
+    }
+  } else {
+    parsed = inputArguments;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return Promise.reject(
+      new DOMException("Input arguments must be a JSON object", "UnknownError"),
+    );
+  }
+
+  if (tool.inputSchema) {
+    try {
+      validateArgs(parsed as Record<string, unknown>, tool.inputSchema);
+    } catch (thrown) {
+      return Promise.reject(thrown);
+    }
+  }
+
+  const controller = new AbortController();
+
+  return new Promise<string>((resolve, reject) => {
+    let settled = false;
+
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      controller.abort(); // default reason → generic AbortError, matching Chrome
+      reject(callerSignal?.reason);
+    };
+    callerSignal?.addEventListener("abort", onAbort, { once: true });
+
+    const onSettle = (result: unknown) => {
+      if (settled) return; // late settlement after abort — ignored
+      settled = true;
+      callerSignal?.removeEventListener("abort", onAbort);
+      try {
+        resolve(serializeResult(result));
+      } catch {
+        reject(new DOMException("Tool result is not JSON-serializable", "UnknownError"));
+      }
+    };
+    const onFail = (thrown: unknown) => {
+      if (settled) return; // late rejection after abort — ignored
+      settled = true;
+      callerSignal?.removeEventListener("abort", onAbort);
+      const message = thrown instanceof Error ? thrown.message : String(thrown);
+      reject(new DOMException(`Tool execution failed: ${message}`, "UnknownError"));
+    };
+
+    // Invoke execute synchronously so its abort listener is attached before a
+    // caller abort in the same turn; a sync throw joins the failure path.
+    try {
+      Promise.resolve(
+        tool.execute(parsed as Record<string, unknown>, { signal: controller.signal }),
+      ).then(onSettle, onFail);
+    } catch (thrown) {
+      onFail(thrown);
+    }
+  });
+}

--- a/src/polyfill/index.ts
+++ b/src/polyfill/index.ts
@@ -1,15 +1,72 @@
-import type { ModelContext } from "../types";
+import type {
+  ExecuteToolOptions,
+  InputSchema,
+  ModelContext,
+  ModelContextGetToolOptions,
+  RegisteredTool,
+} from "../types";
+import { runTool } from "./execute";
 import { createRegistry, type RegistryInternal } from "./registry";
 import { createTestingShim } from "./testing-shim";
+import { isPotentiallyTrustworthyOrigin } from "./validation";
 
 class PolyfillModelContext extends EventTarget {
   readonly __isWebMCPPolyfill = true as const;
   registerTool: ModelContext["registerTool"];
+  #registry: RegistryInternal;
   #ontoolchange: ((ev: Event) => unknown) | null = null;
 
   constructor(registry: RegistryInternal) {
     super();
+    this.#registry = registry;
     this.registerTool = registry.registerTool;
+  }
+
+  getTools(options?: ModelContextGetToolOptions): Promise<RegisteredTool[]> {
+    if (options?.fromOrigins) {
+      for (const origin of options.fromOrigins) {
+        if (!isPotentiallyTrustworthyOrigin(origin)) {
+          return Promise.reject(
+            new DOMException(
+              "Only secure origins are allowed in the fromOrigins list.",
+              "SecurityError",
+            ),
+          );
+        }
+      }
+    }
+    // Single-document polyfill: every registered tool is same-origin, so
+    // fromOrigins never filters anything here.
+    const tools = Array.from(this.#registry.getTools().values())
+      .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+      .map(
+        (tool): RegisteredTool => ({
+          name: tool.name,
+          title: tool.title ?? "",
+          description: tool.description,
+          ...(tool.inputSchema && {
+            // JSON round-trip: a deep copy, matching how Chrome 154 materializes
+            // the object from the schema captured at registration.
+            inputSchema: JSON.parse(JSON.stringify(tool.inputSchema)) as InputSchema,
+          }),
+          ...(tool.annotations && { annotations: { ...tool.annotations } }),
+          window,
+          origin: location.origin,
+        }),
+      );
+    return Promise.resolve(tools);
+  }
+
+  executeTool(
+    tool: RegisteredTool,
+    inputArguments: string | object,
+    options?: ExecuteToolOptions,
+  ): Promise<string | null> {
+    const registered = tool ? this.#registry.get(tool.name) : undefined;
+    if (!registered) {
+      return Promise.reject(new DOMException(`Tool "${tool?.name}" not found`, "UnknownError"));
+    }
+    return runTool(registered, inputArguments, options?.signal);
   }
 
   get ontoolchange(): ((ev: Event) => unknown) | null {

--- a/src/polyfill/registry.ts
+++ b/src/polyfill/registry.ts
@@ -4,6 +4,7 @@ import { isPotentiallyTrustworthyOrigin, isValidToolName } from "./validation";
 export interface RegistryInternal {
   registerTool(tool: ToolDescriptor, options?: RegisterToolOptions): Promise<undefined>;
   getTools(): ReadonlyMap<string, ToolDescriptor>;
+  get(name: string): ToolDescriptor | undefined;
   addChangeListener(callback: () => void): () => void;
 }
 
@@ -94,6 +95,10 @@ export function createRegistry(): RegistryInternal {
 
     getTools(): ReadonlyMap<string, ToolDescriptor> {
       return tools;
+    },
+
+    get(name: string): ToolDescriptor | undefined {
+      return tools.get(name);
     },
 
     addChangeListener(callback: () => void): () => void {

--- a/src/polyfill/testing-shim.ts
+++ b/src/polyfill/testing-shim.ts
@@ -1,4 +1,9 @@
-import type { ModelContextTesting, ModelContextTestingExecuteToolOptions } from "../types";
+import type {
+  CallToolResult,
+  MaybePromise,
+  ModelContextTesting,
+  ModelContextTestingExecuteToolOptions,
+} from "../types";
 import type { RegistryInternal } from "./registry";
 import { validateArgs } from "./validation";
 
@@ -60,7 +65,12 @@ export function createTestingShim(registry: RegistryInternal): ModelContextTesti
       }
 
       try {
-        const resultPromise = Promise.resolve(tool.execute(parsed as Record<string, unknown>));
+        // This deprecated shim predates the two-argument execute(input, options)
+        // signature and intentionally keeps calling with a single argument.
+        const legacyExecute = tool.execute as (
+          input: Record<string, unknown>,
+        ) => MaybePromise<CallToolResult>;
+        const resultPromise = Promise.resolve(legacyExecute(parsed as Record<string, unknown>));
 
         const result = abortPromise
           ? await Promise.race([abortPromise, resultPromise])

--- a/src/polyfill/testing-shim.ts
+++ b/src/polyfill/testing-shim.ts
@@ -1,16 +1,19 @@
-import type {
-  CallToolResult,
-  MaybePromise,
-  ModelContextTesting,
-  ModelContextTestingExecuteToolOptions,
-} from "../types";
+import type { ModelContextTesting, ModelContextTestingExecuteToolOptions } from "../types";
+import { warnOnce } from "../utils/warn";
+import { runTool } from "./execute";
 import type { RegistryInternal } from "./registry";
-import { validateArgs } from "./validation";
 
+const DEPRECATION_KEY = "modelContextTesting-deprecated";
+const DEPRECATION_MSG =
+  "navigator.modelContextTesting is deprecated and will be removed in webmcp-react 2.0.0. " +
+  "Use document.modelContext.getTools() / executeTool() instead.";
+
+/** @deprecated Kept for one release as a wrapper over the modelContext consumer API. */
 export function createTestingShim(registry: RegistryInternal): ModelContextTesting {
   let offChange: (() => void) | null = null;
   return {
     listTools() {
+      warnOnce(DEPRECATION_KEY, DEPRECATION_MSG);
       return Array.from(registry.getTools().values()).map((tool) => ({
         name: tool.name,
         description: tool.description,
@@ -23,65 +26,24 @@ export function createTestingShim(registry: RegistryInternal): ModelContextTesti
       inputArgsJson: string,
       options?: ModelContextTestingExecuteToolOptions,
     ): Promise<string | null> {
-      const tool = registry.getTools().get(toolName);
+      warnOnce(DEPRECATION_KEY, DEPRECATION_MSG);
+      const tool = registry.get(toolName);
       if (!tool) {
         throw new DOMException(`Tool "${toolName}" not found`, "NotFoundError");
       }
 
-      if (options?.signal?.aborted) {
-        throw new DOMException("Tool execution was aborted", "AbortError");
-      }
-
+      // Keep this surface's historical input errors: OperationError, arrays rejected.
       let parsed: unknown;
       try {
         parsed = JSON.parse(inputArgsJson);
       } catch {
         throw new DOMException("Invalid JSON input", "OperationError");
       }
-
       if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
         throw new DOMException("Input must be a JSON object", "OperationError");
       }
 
-      if (tool.inputSchema) {
-        validateArgs(parsed as Record<string, unknown>, tool.inputSchema);
-      }
-
-      const signal = options?.signal;
-      let onAbort: (() => void) | undefined;
-      let abortPromise: Promise<never> | undefined;
-      if (signal) {
-        const abort = { fire: () => {} };
-        const raw = new Promise<never>((_, reject) => {
-          abort.fire = () => reject(new DOMException("Tool execution was aborted", "AbortError"));
-        });
-        raw.catch(() => {});
-        abortPromise = raw;
-        onAbort = abort.fire;
-        signal.addEventListener("abort", onAbort);
-        if (signal.aborted) {
-          onAbort();
-        }
-      }
-
-      try {
-        // This deprecated shim predates the two-argument execute(input, options)
-        // signature and intentionally keeps calling with a single argument.
-        const legacyExecute = tool.execute as (
-          input: Record<string, unknown>,
-        ) => MaybePromise<CallToolResult>;
-        const resultPromise = Promise.resolve(legacyExecute(parsed as Record<string, unknown>));
-
-        const result = abortPromise
-          ? await Promise.race([abortPromise, resultPromise])
-          : await resultPromise;
-
-        return JSON.stringify(result);
-      } finally {
-        if (onAbort && signal) {
-          signal.removeEventListener("abort", onAbort);
-        }
-      }
+      return runTool(tool, parsed as Record<string, unknown>, options?.signal);
     },
 
     registerToolsChangedCallback(callback: () => void) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,16 @@ import type * as z4 from "zod/v4/core";
 
 export type MaybePromise<T> = T | Promise<T>;
 
+/** Second argument to a tool's execute callback / useMcpTool handler (Chrome 153+ shape). */
+export interface ToolExecuteCallbackOptions {
+  signal: AbortSignal;
+}
+
+/** Options for ModelContext.executeTool and UseMcpToolReturn.execute. */
+export interface ExecuteToolOptions {
+  signal?: AbortSignal;
+}
+
 export interface InputSchemaProperty {
   type: string;
   description?: string;
@@ -75,7 +85,7 @@ export interface ToolDescriptor<TArgs = Record<string, unknown>> {
   inputSchema?: InputSchema;
   outputSchema?: InputSchema;
   annotations?: ToolAnnotations;
-  execute: (input: TArgs) => MaybePromise<CallToolResult>;
+  execute: (input: TArgs, options: ToolExecuteCallbackOptions) => MaybePromise<CallToolResult>;
 }
 
 interface McpToolConfigBase {
@@ -103,7 +113,7 @@ export interface McpToolConfigZod<T extends ZodObjectSchema = ZodObjectSchema>
   inputSchema?: never;
   output?: ZodObjectSchema;
   outputSchema?: never;
-  handler: (args: ZodParsed<T>) => MaybePromise<CallToolResult>;
+  handler: (args: ZodParsed<T>, ctx: ToolExecuteCallbackOptions) => MaybePromise<CallToolResult>;
 }
 
 export interface McpToolConfigJsonSchema extends McpToolConfigBase {
@@ -111,7 +121,10 @@ export interface McpToolConfigJsonSchema extends McpToolConfigBase {
   inputSchema?: InputSchema;
   output?: never;
   outputSchema?: InputSchema;
-  handler: (args: Record<string, unknown>) => MaybePromise<CallToolResult>;
+  handler: (
+    args: Record<string, unknown>,
+    ctx: ToolExecuteCallbackOptions,
+  ) => MaybePromise<CallToolResult>;
 }
 
 export interface ToolExecutionState<TResult = CallToolResult> {
@@ -123,7 +136,7 @@ export interface ToolExecutionState<TResult = CallToolResult> {
 
 export interface UseMcpToolReturn<TResult = CallToolResult> {
   state: ToolExecutionState<TResult>;
-  execute: (input?: Record<string, unknown>) => Promise<TResult>;
+  execute: (input?: Record<string, unknown>, options?: ExecuteToolOptions) => Promise<TResult>;
   reset: () => void;
 }
 
@@ -142,8 +155,34 @@ export interface RegisterToolOptions {
   exposedTo?: string[];
 }
 
+/**
+ * Tool metadata returned by ModelContext.getTools().
+ * `inputSchema` is an object on Chrome 154+ and this library's polyfill, but a
+ * JSON string on Chrome <=153 — consumers must handle both:
+ * `typeof s === "string" ? JSON.parse(s) : s`.
+ */
+export interface RegisteredTool {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema?: InputSchema | string;
+  annotations?: ToolAnnotations;
+  window?: Window;
+  origin?: string;
+}
+
+export interface ModelContextGetToolOptions {
+  fromOrigins?: string[];
+}
+
 export interface ModelContext extends EventTarget {
   registerTool(tool: ToolDescriptor, options?: RegisterToolOptions): Promise<undefined>;
+  getTools?(options?: ModelContextGetToolOptions): Promise<RegisteredTool[]>;
+  executeTool?(
+    tool: RegisteredTool,
+    inputArguments: string | object,
+    options?: ExecuteToolOptions,
+  ): Promise<string | null>;
   ontoolchange: ((this: ModelContext, ev: Event) => unknown) | null;
   addEventListener(
     type: "toolchange",
@@ -157,16 +196,19 @@ export interface ModelContext extends EventTarget {
   ): void;
 }
 
+/** @deprecated Removed from native Chrome in 152; use ModelContext.getTools()/executeTool(). Will be removed in webmcp-react 2.0.0. */
 export interface ModelContextTestingToolInfo {
   name: string;
   description: string;
   inputSchema?: string;
 }
 
+/** @deprecated Removed from native Chrome in 152. Will be removed in webmcp-react 2.0.0. */
 export interface ModelContextTestingExecuteToolOptions {
   signal?: AbortSignal;
 }
 
+/** @deprecated Removed from native Chrome in 152; use document.modelContext.getTools()/executeTool(). Will be removed in webmcp-react 2.0.0. */
 export interface ModelContextTesting {
   listTools(): ModelContextTestingToolInfo[];
   executeTool(


### PR DESCRIPTION
## What changed

Built on #53 (the 1.0.0 release, now merged) — this is the 1.1.0 delta on top of it.

Chrome's WebMCP implementation moved in three steps (per the Chrome WebMCP team's EPP announcements, checked against Chromium source):

1. **152.0.7940.0** removed `navigator.modelContextTesting`. The consumer API is `document.modelContext.getTools()` / `executeTool()` (shipping since 150.0.7861.0).
2. **153.0.8007.0** calls a tool's `execute` as `execute(input, { signal })` — [webmcp issue #48](https://github.com/webmachinelearning/webmcp/issues/48), [spec PR #247](https://github.com/webmachinelearning/webmcp/pull/247). From 153.0.8008.0, unregistering a tool no longer cancels its in-flight executions ([issue #218](https://github.com/webmachinelearning/webmcp/issues/218)).
3. **154.0.8014.0** changed `RegisteredTool.inputSchema` from a JSON string to an object ([spec PR #241](https://github.com/webmachinelearning/webmcp/pull/241)).

### Library

- **`src/types.ts`** — `ToolDescriptor.execute` and the config `handler` take `(input, { signal })`. New `ToolExecuteCallbackOptions`, `ExecuteToolOptions`, `RegisteredTool` (`inputSchema: InputSchema | string`, since 153 and 154 differ), `ModelContextGetToolOptions`; `ModelContext` gains optional `getTools`/`executeTool`. One-argument handlers still type-check.
- **`src/hooks/useMcpTool.ts`** — the direct `execute()` path and the registered descriptor now share one `runHandler`. Handlers always receive a real `AbortSignal`; on Chrome <=152 (which passes no options) a never-aborting one is substituted. When an aborted execution's handler rejects it's treated as cancellation: `isExecuting` clears, `state.error` and `onError` are left alone. `execute(input?, { signal }?)` accepts a caller signal.
- **`src/polyfill/execute.ts`** (new) — one execution engine behind both `executeTool` and the shim: per-execution `AbortController`, a caller abort rejects with `signal.reason` while the tool-side signal aborts with a generic `AbortError` (what 153 does), late settlement after abort is ignored, tool failures reject `UnknownError`, results serialize the way native does. Input is still validated against `inputSchema` (`OperationError`); native doesn't validate yet ([issue #92](https://github.com/webmachinelearning/webmcp/issues/92)).
- **`src/polyfill/index.ts`** — `document.modelContext.getTools()` / `executeTool()` on the polyfill: fresh sorted objects, deep-copied object `inputSchema` (the 154 shape), `fromOrigins` validation, `UnknownError` for a stale tool. In-flight executions survive unregistration.
- **`src/polyfill/testing-shim.ts`** — now a thin wrapper over the engine that warns once that `navigator.modelContextTesting` is deprecated (removal planned for 2.0.0). Keeps its historical `NotFoundError`/`OperationError` input errors.
- **Docs** — README, `docs/api.md` (Cancellation section and a Chrome compat table), AGENTS.md, both skills, CHANGELOG. **Version bump to 1.1.0.**

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` (zero warnings) / `pnpm build`
- [x] `pnpm test` — 205 passing: both execution paths, cancellation semantics, engine abort races and serialization, consumer API, shim parity
- [ ] Harness self-test against native Chrome 153+/154 Canary — only the polyfill has been exercised so far

The extension and examples migration is stacked on this branch in a follow-up PR.


