### PR TITLE
Release prep: agentcathq metadata, webmcp-server + extension 0.2.0, server publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,3 +23,20 @@ jobs:
       - run: pnpm build
       - run: pnpm test
       - run: npm publish --provenance --access public
+
+  publish-server:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/webmcp-server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - id: check
+        run: |
+          v=$(node -p "require('./package.json').version")
+          if npm view "webmcp-server@$v" version >/dev/null 2>&1; then echo "skip=true" >> "$GITHUB_OUTPUT"; fi
+      - if: steps.check.outputs.skip != 'true'
+        run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,6 @@ All notable changes to `webmcp-react` are documented here. The format is based o
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### Extension
-
-- The bridge extension now discovers and executes tools via
-  `document.modelContext.getTools()` / `executeTool()` (native Chrome 150.0.7861.0+ and the
-  webmcp-react 1.1.0 polyfill), falling back to the deprecated
-  `navigator.modelContextTesting` for pages on webmcp-react ≤1.0.0. Native Chrome removed
-  `modelContextTesting` in 152.0.7940.0, which had left the extension unable to see tools
-  on native Chrome.
-- MCP client cancellations (`notifications/cancelled`) are forwarded end-to-end: MCP SDK →
-  WebSocket `CANCEL_TOOL` → background → content scripts → `executeTool`'s `AbortSignal`,
-  aborting the tool handler's execution signal.
-
 ## 1.1.0
 
 Tracks Chrome 152–154 WebMCP changes: execution AbortSignals, the
@@ -57,6 +43,19 @@ Tracks Chrome 152–154 WebMCP changes: execution AbortSignals, the
 - **`navigator.modelContextTesting`.** Native Chrome removed it in 152.0.7940.0. The
   polyfill's shim now delegates to the same engine as `document.modelContext.executeTool()`
   and warns once in dev. It will be removed in webmcp-react 2.0.0.
+
+### Extension
+
+- The bridge extension now discovers and executes tools via
+  `document.modelContext.getTools()` / `executeTool()` (native Chrome 150.0.7861.0+ and the
+  webmcp-react 1.1.0 polyfill), falling back to the deprecated
+  `navigator.modelContextTesting` for pages on webmcp-react ≤1.0.0. Native Chrome removed
+  `modelContextTesting` in 152.0.7940.0, which had left the extension unable to see tools
+  on native Chrome.
+- MCP client cancellations (`notifications/cancelled`) are forwarded end-to-end: MCP SDK →
+  WebSocket `CANCEL_TOOL` → background → content scripts → `executeTool`'s `AbortSignal`,
+  aborting the tool handler's execution signal.
+- Ships as `webmcp-server` 0.2.0 (the bin is regenerated) and bridge extension 0.2.0.
 
 ## 1.0.0
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WebMCP Bridge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Expose your web app's tools to AI assistants like Claude and Cursor via the Model Context Protocol",
   "permissions": ["tabs", "scripting", "activeTab", "storage"],
   "optional_host_permissions": ["https://*/*", "http://*/*"],

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmcp-bridge-extension",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MCPCat/webmcp-react.git"
+    "url": "https://github.com/agentcathq/webmcp-react.git"
   },
-  "homepage": "https://github.com/MCPCat/webmcp-react",
+  "homepage": "https://github.com/agentcathq/webmcp-react",
   "bugs": {
-    "url": "https://github.com/MCPCat/webmcp-react/issues"
+    "url": "https://github.com/agentcathq/webmcp-react/issues"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/webmcp-server/package.json
+++ b/packages/webmcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server that bridges WebMCP browser tools to AI clients like Claude Code and Cursor",
   "type": "module",
   "bin": {
@@ -15,18 +15,18 @@
     "model-context-protocol",
     "ai",
     "chrome-extension",
-    "navigator.modelContext"
+    "document.modelContext"
   ],
   "author": "Kashish Hora",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MCPCat/webmcp-react.git",
+    "url": "https://github.com/agentcathq/webmcp-react.git",
     "directory": "packages/webmcp-server"
   },
-  "homepage": "https://github.com/MCPCat/webmcp-react/tree/main/packages/webmcp-server",
+  "homepage": "https://github.com/agentcathq/webmcp-react/tree/main/packages/webmcp-server",
   "bugs": {
-    "url": "https://github.com/MCPCat/webmcp-react/issues"
+    "url": "https://github.com/agentcathq/webmcp-react/issues"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",


### PR DESCRIPTION
## What changed

Housekeeping needed before cutting the 1.1.0 release.

- **`package.json` / `packages/webmcp-server/package.json`** — `repository`, `homepage`, and `bugs` now point at `agentcathq/webmcp-react`. The repo was renamed; `npm publish --provenance` verifies `repository.url` against the repo the workflow runs in and rejects a mismatch, so publishing would fail as-is. Also dropped the stale `navigator.modelContext` keyword from the server package.
- **`webmcp-server` → 0.2.0** — its bin picked up the `CANCEL_TOOL` forwarding in #55.
- **Bridge extension → 0.2.0** (`manifest.json`, `extension/package.json`) — it now runs on native Chrome ≥152 again and forwards cancellations.
- **`.github/workflows/publish.yml`** — a second `publish-server` job publishes `packages/webmcp-server` with provenance on the same release event, skipping if that version is already on npm (so library-only releases don't fail the job).
- **CHANGELOG** — the extension notes move from Unreleased into 1.1.0, since they ship on the same tag.

## Test plan

- [x] `pnpm install --frozen-lockfile` still clean; `pnpm test` passing (209)
- [ ] After merge: cut the `v1.1.0` GitHub Release and watch both publish jobs. `webmcp-server` needs its own trusted-publisher entry on npmjs.com (`agentcathq/webmcp-react`, `publish.yml`) or its job will fail — the library's entry should be checked for the rename too.
