### PR TITLE
docs: fix README Wordle demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install webmcp-react zod
 
 ## Playground
 
-Try it live: [**WebMCP Wordle Demo**](https://mcpcat.github.io/webmcp-react/playground/)
+Try it live: [**WebMCP Wordle Demo**](https://agentcathq.github.io/webmcp-react/playground/)
 
 A fully playable Wordle clone that showcases `webmcp-react` hooks. Tools dynamically register and unregister as the game moves through phases (idle, playing, won/lost), and guesses can be made via keyboard or through a connected MCP agent. Includes a DevPanel for inspecting tool state and an easy-mode toggle that enables a hint tool. Install the Chrome extension to bridge tools to AI clients like Claude and Cursor.
 


### PR DESCRIPTION
## Summary
- Point the README playground link at `https://agentcathq.github.io/webmcp-react/playground/`
- The repo moved to the agentcathq org, so the old `mcpcat.github.io` URL returns 404 and the new one returns 200

## Test plan
- [x] Old URL returns 404, new URL returns 200 (checked with curl)
- [x] `grep -rn mcpcat.github.io` finds no other references