### PR TITLE
fix(extension): three ways a tab loses its tools

### DIFF
--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -32,8 +32,11 @@ function installChrome(opts: {
     storage: {
       local: {
         get: async () => {
+          // Snapshot at request time: the real store answers a get issued
+          // before a set with the old value.
+          const domains = stored.domains;
           await opts.storageDelay();
-          return { activatedDomains: stored.domains };
+          return { activatedDomains: domains };
         },
         set: async (items: any) => {
           stored.domains = items.activatedDomains;
@@ -216,5 +219,83 @@ describe("an in-app route change", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(await statusToolNames(ctx.messageListeners, 7)).toEqual([]);
+  });
+});
+
+
+describe("handlers that arrive before the persisted activations load", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  function installWithDelayedStorage(domains: string[]) {
+    let releaseStorage: () => void = () => {};
+    const storageRead = new Promise<void>((r) => {
+      releaseStorage = r;
+    });
+    const ctx = installChrome({ domains, storageDelay: () => storageRead });
+    return { ...ctx, releaseStorage };
+  }
+
+  it("GET_STATUS reports the persisted activation instead of a premature off", async () => {
+    const { messageListeners, releaseStorage } = installWithDelayedStorage(["https://app.example"]);
+    await import("../background");
+
+    const pending = send(messageListeners, { type: "GET_STATUS", tabId: 7 });
+    releaseStorage();
+    const status = await pending;
+
+    expect(status?.currentTabActivation).toBe("domain");
+  });
+
+  it("DEACTIVATE_DOMAIN is not undone by the activation loading behind it", async () => {
+    const { messageListeners, stored, releaseStorage } = installWithDelayedStorage([
+      "https://app.example",
+    ]);
+    await import("../background");
+
+    const pending = send(messageListeners, {
+      type: "DEACTIVATE_DOMAIN",
+      origin: "https://app.example",
+    });
+    releaseStorage();
+    await pending;
+
+    const status = await send(messageListeners, { type: "GET_STATUS", tabId: 7 });
+    expect(status?.activatedDomains).toEqual([]);
+    expect(stored.domains).toEqual([]);
+  });
+
+  it("ACTIVATE_DOMAIN does not overwrite the activations still loading", async () => {
+    const { messageListeners, stored, releaseStorage } = installWithDelayedStorage([
+      "https://a.example",
+    ]);
+    await import("../background");
+
+    const pending = send(messageListeners, {
+      type: "ACTIVATE_DOMAIN",
+      tabId: 7,
+      origin: "https://b.example",
+    });
+    releaseStorage();
+    await pending;
+
+    expect(stored.domains).toEqual(["https://a.example", "https://b.example"]);
+  });
+
+  it("a tab activation still reports its tools when the storage read fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { messageListeners } = installChrome({
+      domains: [],
+      storageDelay: () => Promise.reject(new Error("storage unavailable")),
+    });
+    await import("../background");
+
+    await send(messageListeners, { type: "ACTIVATE_TAB", tabId: 7 });
+    await send(messageListeners, { type: "TOOLS_UPDATED", tools: TOOLS }, SENDER);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(messageListeners, 7)).toEqual(["reflow_run"]);
+    errorSpy.mockRestore();
   });
 });

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -139,3 +139,46 @@ describe("an in-app route change", () => {
     expect(await statusToolNames(ctx.messageListeners, 7)).toEqual([]);
   });
 });
+
+describe("TOOLS_UPDATED before the persisted activations load", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("keeps the tools of a domain that was activated in a previous session", async () => {
+    let releaseStorage: () => void = () => {};
+    const storageRead = new Promise<void>((r) => {
+      releaseStorage = r;
+    });
+
+    const { messageListeners } = installChrome({
+      domains: ["https://app.example"],
+      storageDelay: () => storageRead,
+    });
+
+    await import("../background");
+
+    // The page registers while chrome.storage.local.get is still in flight.
+    await send(messageListeners, { type: "TOOLS_UPDATED", tools: TOOLS }, SENDER);
+
+    releaseStorage();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(messageListeners, 7)).toEqual(["reflow_run"]);
+  });
+
+  it("still drops the tools of a tab that is not activated", async () => {
+    const { messageListeners } = installChrome({
+      domains: [],
+      storageDelay: async () => {},
+    });
+
+    await import("../background");
+    await send(messageListeners, { type: "TOOLS_UPDATED", tools: TOOLS }, SENDER);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(messageListeners, 7)).toEqual([]);
+  });
+});
+
+

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -100,46 +100,6 @@ const SENDER = {
   tab: { id: 7, url: "https://app.example/flow", title: "Flow" },
 };
 
-describe("an in-app route change", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
-
-  async function loadWithTools() {
-    const ctx = installChrome({
-      domains: ["https://app.example"],
-      storageDelay: async () => {},
-    });
-    await import("../background");
-    await send(ctx.messageListeners, { type: "TOOLS_UPDATED", tools: TOOLS }, SENDER);
-    await new Promise((r) => setTimeout(r, 0));
-    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual(["reflow_run"]);
-    return ctx;
-  }
-
-  it("keeps the tools when only the fragment changes", async () => {
-    const ctx = await loadWithTools();
-
-    for (const l of ctx.updatedListeners) {
-      l(7, { status: "loading", url: "https://app.example/flow#/regions?search=" });
-    }
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual(["reflow_run"]);
-  });
-
-  it("drops them when the document itself changes", async () => {
-    const ctx = await loadWithTools();
-
-    for (const l of ctx.updatedListeners) {
-      l(7, { status: "loading", url: "https://app.example/other" });
-    }
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual([]);
-  });
-});
-
 describe("TOOLS_UPDATED before the persisted activations load", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -182,3 +142,79 @@ describe("TOOLS_UPDATED before the persisted activations load", () => {
 });
 
 
+describe("a persisted domain whose host permission is gone", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("is dropped, so the popup does not report a domain nothing can reach", async () => {
+    const { registeredScripts, stored } = installChrome({
+      domains: ["https://app.example"],
+      grantedOrigins: [],
+      storageDelay: async () => {},
+    });
+
+    await import("../background");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(stored.domains).toEqual([]);
+    expect(registeredScripts).toEqual([]);
+  });
+
+  it("is kept, and its content scripts registered, while the permission holds", async () => {
+    const { registeredScripts, stored } = installChrome({
+      domains: ["https://app.example"],
+      storageDelay: async () => {},
+    });
+
+    await import("../background");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(stored.domains).toEqual(["https://app.example"]);
+    expect(registeredScripts).toEqual([
+      "https://app.example/*",
+      "https://app.example/*",
+    ]);
+  });
+});
+
+
+describe("an in-app route change", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  async function loadWithTools() {
+    const ctx = installChrome({
+      domains: ["https://app.example"],
+      storageDelay: async () => {},
+    });
+    await import("../background");
+    await send(ctx.messageListeners, { type: "TOOLS_UPDATED", tools: TOOLS }, SENDER);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual(["reflow_run"]);
+    return ctx;
+  }
+
+  it("keeps the tools when only the fragment changes", async () => {
+    const ctx = await loadWithTools();
+
+    for (const l of ctx.updatedListeners) {
+      l(7, { status: "loading", url: "https://app.example/flow#/regions?search=" });
+    }
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual(["reflow_run"]);
+  });
+
+  it("drops them when the document itself changes", async () => {
+    const ctx = await loadWithTools();
+
+    for (const l of ctx.updatedListeners) {
+      l(7, { status: "loading", url: "https://app.example/other" });
+    }
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual([]);
+  });
+});

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The service worker is restarted whenever Chrome decides it has been idle,
+ * and that re-runs background.ts with an empty activation set. A content
+ * script on an already-activated domain can report its tools during the
+ * window where storage has not been read back yet.
+ */
+
+type Listener = (
+  message: any,
+  sender: any,
+  sendResponse: (r?: any) => void,
+) => boolean | void;
+
+function installChrome(opts: {
+  domains: string[];
+  storageDelay: () => Promise<void>;
+  grantedOrigins?: string[];
+}) {
+  const messageListeners: Listener[] = [];
+  const updatedListeners: ((tabId: number, changeInfo: any) => void)[] = [];
+  const registeredScripts: string[] = [];
+  const stored: { domains: string[] } = { domains: opts.domains };
+  const granted = opts.grantedOrigins ?? opts.domains;
+
+  const chromeMock = {
+    runtime: {
+      onMessage: { addListener: (l: Listener) => messageListeners.push(l) },
+      lastError: undefined,
+    },
+    storage: {
+      local: {
+        get: async () => {
+          await opts.storageDelay();
+          return { activatedDomains: stored.domains };
+        },
+        set: async (items: any) => {
+          stored.domains = items.activatedDomains;
+        },
+      },
+    },
+    tabs: {
+      get: async (id: number) => ({ id, url: "https://app.example/flow" }),
+      onRemoved: { addListener: () => {} },
+      onUpdated: {
+        addListener: (l: (tabId: number, changeInfo: any) => void) =>
+          updatedListeners.push(l),
+      },
+      sendMessage: async () => {},
+    },
+    scripting: {
+      registerContentScripts: async (scripts: any[]) => {
+        for (const sc of scripts) registeredScripts.push(sc.matches[0]);
+      },
+      unregisterContentScripts: async () => {},
+      getRegisteredContentScripts: async () => [],
+      executeScript: async () => [],
+    },
+    permissions: {
+      remove: async () => true,
+      contains: async ({ origins }: { origins: string[] }) =>
+        granted.some((o) => origins[0] === `${o}/*`),
+    },
+    action: { setBadgeText: () => {}, setBadgeBackgroundColor: () => {}, setTitle: () => {} },
+  };
+
+  (globalThis as any).chrome = chromeMock;
+
+  // Never let the module open a real socket.
+  (globalThis as any).WebSocket = class {
+    onopen: (() => void) | null = null;
+    onmessage: (() => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    readyState = 0;
+    send() {}
+    close() {}
+  };
+
+  return { messageListeners, updatedListeners, registeredScripts, stored };
+}
+
+function send(listeners: Listener[], message: any, sender: any = {}) {
+  return new Promise<any>((resolve) => {
+    for (const l of listeners) l(message, sender, resolve);
+    // Fire-and-forget messages never respond.
+    setTimeout(() => resolve(undefined), 0);
+  });
+}
+
+async function statusToolNames(listeners: Listener[], tabId: number) {
+  const status = await send(listeners, { type: "GET_STATUS", tabId }, {});
+  const tab = status?.tabs?.find((t: any) => t.tabId === tabId);
+  return tab ? tab.toolNames : [];
+}
+
+const TOOLS = [{ name: "reflow_run", description: "d", inputSchema: { type: "object" } }];
+const SENDER = {
+  tab: { id: 7, url: "https://app.example/flow", title: "Flow" },
+};
+
+describe("an in-app route change", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  async function loadWithTools() {
+    const ctx = installChrome({
+      domains: ["https://app.example"],
+      storageDelay: async () => {},
+    });
+    await import("../background");
+    await send(ctx.messageListeners, { type: "TOOLS_UPDATED", tools: TOOLS }, SENDER);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual(["reflow_run"]);
+    return ctx;
+  }
+
+  it("keeps the tools when only the fragment changes", async () => {
+    const ctx = await loadWithTools();
+
+    for (const l of ctx.updatedListeners) {
+      l(7, { status: "loading", url: "https://app.example/flow#/regions?search=" });
+    }
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual(["reflow_run"]);
+  });
+
+  it("drops them when the document itself changes", async () => {
+    const ctx = await loadWithTools();
+
+    for (const l of ctx.updatedListeners) {
+      l(7, { status: "loading", url: "https://app.example/other" });
+    }
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual([]);
+  });
+});

--- a/extension/src/__tests__/background.test.ts
+++ b/extension/src/__tests__/background.test.ts
@@ -299,3 +299,58 @@ describe("handlers that arrive before the persisted activations load", () => {
     errorSpy.mockRestore();
   });
 });
+
+describe("the url a same-document check compares against", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("is known for a tab activation before the page has reported", async () => {
+    const ctx = installChrome({ domains: [], storageDelay: async () => {} });
+    await import("../background");
+    await send(ctx.messageListeners, { type: "ACTIVATE_TAB", tabId: 7 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    for (const l of ctx.updatedListeners) {
+      l(7, { status: "loading", url: "https://app.example/flow#/settings" });
+    }
+    await send(ctx.messageListeners, { type: "TOOLS_UPDATED", tools: TOOLS }, SENDER);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual(["reflow_run"]);
+  });
+
+  it("is the full url, not the 500-char copy kept for display", async () => {
+    const longUrl = `https://app.example/flow?q=${"x".repeat(600)}`;
+    const ctx = installChrome({ domains: ["https://app.example"], storageDelay: async () => {} });
+    await import("../background");
+    await send(
+      ctx.messageListeners,
+      { type: "TOOLS_UPDATED", tools: TOOLS },
+      { tab: { id: 7, url: longUrl, title: "Flow" } },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+
+    for (const l of ctx.updatedListeners) {
+      l(7, { status: "loading", url: `${longUrl}#/b` });
+    }
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await statusToolNames(ctx.messageListeners, 7)).toEqual(["reflow_run"]);
+  });
+
+  it("follows a kept navigation, and so does the url shown for the tab", async () => {
+    const ctx = installChrome({ domains: ["https://app.example"], storageDelay: async () => {} });
+    await import("../background");
+    await send(ctx.messageListeners, { type: "TOOLS_UPDATED", tools: TOOLS }, SENDER);
+    await new Promise((r) => setTimeout(r, 0));
+
+    for (const l of ctx.updatedListeners) {
+      l(7, { status: "loading", url: "https://app.example/flow#/b" });
+    }
+    await new Promise((r) => setTimeout(r, 0));
+
+    const status = await send(ctx.messageListeners, { type: "GET_STATUS", tabId: 7 });
+    expect(status?.tabs?.[0]?.url).toBe("https://app.example/flow#/b");
+  });
+});

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -156,9 +156,6 @@ async function persistDomains() {
   });
 }
 
-// Resolves once the persisted activations are in memory. A service worker
-// restart re-runs this file, and a content script can report its tools before
-// storage has been read, so handlers that decide on activation wait for this.
 async function hasHostPermission(origin: string): Promise<boolean> {
   try {
     return await chrome.permissions.contains({ origins: [`${origin}/*`] });
@@ -197,7 +194,9 @@ async function loadPersistedDomains() {
 // Resolves once the persisted activations are in memory. A service worker
 // restart re-runs this file, and a content script can report its tools before
 // storage has been read, so handlers that decide on activation wait for this.
-const domainsReady: Promise<void> = loadPersistedDomains();
+const domainsReady: Promise<void> = loadPersistedDomains().catch((err) => {
+  console.error("[WebMCP Bridge] loadPersistedDomains:", err);
+});
 
 async function registerContentScriptsForDomains(origins: string[]) {
   const scripts: chrome.scripting.RegisteredContentScript[] = [];
@@ -498,22 +497,25 @@ chrome.runtime.onMessage.addListener(
       }
       case "ACTIVATE_DOMAIN": {
         const { tabId, origin } = message;
-        activatedDomains.add(origin);
-      
-        Promise.all([
-          persistDomains(),
-          registerContentScriptsForDomains([origin]),
-          // Also inject into current tab immediately
-          activatedTabs.has(tabId)
-            ? Promise.resolve()
-            : injectContentScripts(tabId),
-        ]).then(
-          () => {
-            activatedTabs.add(tabId);
-            sendResponse({ ok: true });
-          },
-          (err) => sendResponse({ ok: false, error: String(err) }),
-        );
+        // Wait for the persisted activations so persistDomains writes the
+        // full set rather than just this origin.
+        domainsReady
+          .then(() => {
+            activatedDomains.add(origin);
+            return Promise.all([
+              persistDomains(),
+              registerContentScriptsForDomains([origin]),
+              // Also inject into current tab immediately
+              activatedTabs.has(tabId) ? Promise.resolve() : injectContentScripts(tabId),
+            ]);
+          })
+          .then(
+            () => {
+              activatedTabs.add(tabId);
+              sendResponse({ ok: true });
+            },
+            (err) => sendResponse({ ok: false, error: String(err) }),
+          );
         return true;
       }
       case "DEACTIVATE_TAB": {
@@ -530,30 +532,36 @@ chrome.runtime.onMessage.addListener(
       }
       case "DEACTIVATE_DOMAIN": {
         const { origin } = message;
-        activatedDomains.delete(origin);
-      
+        // Wait for the persisted activations, or the loader adds this origin
+        // straight back after it was removed here.
+        domainsReady
+          .then(() => {
+            activatedDomains.delete(origin);
 
-        // Purge tools from tabs on this origin — but only if not still authorized via activatedTabs
-        for (const [tabId, info] of tabTools) {
-          if (originFromUrl(info.url) === origin && !activatedTabs.has(tabId)) {
-            purgeTabTools(tabId);
-          }
-        }
+            // Purge tools from tabs on this origin — but only if not still authorized via activatedTabs
+            for (const [tabId, info] of tabTools) {
+              if (originFromUrl(info.url) === origin && !activatedTabs.has(tabId)) {
+                purgeTabTools(tabId);
+              }
+            }
 
-        Promise.all([
-          persistDomains(),
-          unregisterContentScriptsForDomain(origin),
-          chrome.permissions.remove({ origins: [`${origin}/*`] }),
-        ]).then(
-          () => sendResponse({ ok: true }),
-          (err) => sendResponse({ ok: false, error: String(err) }),
-        );
+            return Promise.all([
+              persistDomains(),
+              unregisterContentScriptsForDomain(origin),
+              chrome.permissions.remove({ origins: [`${origin}/*`] }),
+            ]);
+          })
+          .then(
+            () => sendResponse({ ok: true }),
+            (err) => sendResponse({ ok: false, error: String(err) }),
+          );
         return true;
       }
       case "GET_STATUS": {
         const queryTabId = message.tabId;
         // Look up the tab URL for activation status
         const getActivation = async (): Promise<"off" | "tab" | "domain"> => {
+          await domainsReady;
           if (queryTabId == null) return "off";
           try {
             const tab = await chrome.tabs.get(queryTabId);

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -159,14 +159,38 @@ async function persistDomains() {
 // Resolves once the persisted activations are in memory. A service worker
 // restart re-runs this file, and a content script can report its tools before
 // storage has been read, so handlers that decide on activation wait for this.
+async function hasHostPermission(origin: string): Promise<boolean> {
+  try {
+    return await chrome.permissions.contains({ origins: [`${origin}/*`] });
+  } catch {
+    return false;
+  }
+}
+
 async function loadPersistedDomains() {
   const data = await chrome.storage.local.get(STORAGE_KEY);
-  const domains: string[] = data[STORAGE_KEY] ?? [];
-  for (const d of domains) {
+  const stored: string[] = data[STORAGE_KEY] ?? [];
+
+  // Host permissions are optional and are not guaranteed to outlive the
+  // activation stored here: reinstalling the extension keeps its storage and
+  // drops its granted origins. Content scripts cannot be registered for an
+  // origin we no longer hold, so keeping it would leave the popup reporting a
+  // domain as active while nothing on it can be reached.
+  const granted: string[] = [];
+  for (const origin of stored) {
+    if (await hasHostPermission(origin)) granted.push(origin);
+  }
+
+  for (const d of granted) {
     activatedDomains.add(d);
   }
-  if (domains.length > 0) {
-    await registerContentScriptsForDomains(domains);
+
+  if (granted.length !== stored.length) {
+    await persistDomains();
+  }
+
+  if (granted.length > 0) {
+    await registerContentScriptsForDomains(granted);
   }
 }
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -16,6 +16,11 @@ const tabTools = new Map<
   { tools: BrowserTool[]; title: string; url: string }
 >();
 
+// The last url seen for each tab, kept in full. tabTools only holds a
+// 500-char copy for display, and only once the page has reported, but the
+// navigation listener needs a url to compare against in both cases.
+const tabUrls = new Map<number, string>();
+
 const pendingCalls = new Map<string, number>();
 
 // Activation state
@@ -251,6 +256,19 @@ async function injectContentScripts(tabId: number) {
   });
 }
 
+function rememberTabUrl(tabId: number, url: string | undefined) {
+  if (url) tabUrls.set(tabId, url);
+}
+
+// The popup only sends a tab id, so look the url up for activations that
+// happen before the page has reported anything.
+function rememberTabUrlFromChrome(tabId: number) {
+  chrome.tabs.get(tabId).then(
+    (tab) => rememberTabUrl(tabId, tab.url),
+    () => {},
+  );
+}
+
 function purgeTabTools(tabId: number) {
   if (tabTools.has(tabId)) {
     tabTools.delete(tabId);
@@ -448,6 +466,7 @@ chrome.runtime.onMessage.addListener(
         // registers during that window loses its tools until it registers
         // again. Decide once the activations are in memory.
         void domainsReady.then(() => {
+          rememberTabUrl(tabId, url);
           if (!isTabAuthorized(tabId, url)) {
             // Stale content script from a deactivated tab — purge and ignore
             purgeTabTools(tabId);
@@ -488,7 +507,8 @@ chrome.runtime.onMessage.addListener(
           return true;
         }
         activatedTabs.add(tabId);
-      
+        rememberTabUrlFromChrome(tabId);
+
         injectContentScripts(tabId).then(
           () => sendResponse({ ok: true }),
           (err) => sendResponse({ ok: false, error: String(err) }),
@@ -497,6 +517,7 @@ chrome.runtime.onMessage.addListener(
       }
       case "ACTIVATE_DOMAIN": {
         const { tabId, origin } = message;
+        rememberTabUrlFromChrome(tabId);
         // Wait for the persisted activations so persistDomains writes the
         // full set rather than just this origin.
         domainsReady
@@ -597,6 +618,7 @@ chrome.runtime.onMessage.addListener(
 // Clean up when tabs close
 chrome.tabs.onRemoved.addListener((tabId) => {
   activatedTabs.delete(tabId);
+  tabUrls.delete(tabId);
   if (tabTools.has(tabId)) {
     tabTools.delete(tabId);
     rejectPendingCallsForTab(tabId);
@@ -606,13 +628,16 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 
 // Clean up when tabs navigate
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  const last = tabUrls.get(tabId);
+  rememberTabUrl(tabId, changeInfo.url);
   if (changeInfo.status !== "loading") return;
 
   // A fragment change is a same-document navigation, which routers use for
   // every in-app route: the document keeps the tools it registered and content
   // scripts do not run again, so there would be nothing left to report them.
-  const known = tabTools.get(tabId);
-  if (known && changeInfo.url && isSameDocument(known.url, changeInfo.url)) {
+  if (last && changeInfo.url && isSameDocument(last, changeInfo.url)) {
+    const known = tabTools.get(tabId);
+    if (known) known.url = sanitize(changeInfo.url, 500);
     if (DEBUG) console.log("[WebMCP Bridge] same-document navigation, keeping tools", changeInfo.url);
     return;
   }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -68,6 +68,19 @@ function originHash(origin: string): string {
   return Math.abs(hash).toString(36);
 }
 
+/** Whether two urls address the same document, i.e. differ only by fragment. */
+function isSameDocument(a: string, b: string): boolean {
+  try {
+    const ua = new URL(a);
+    const ub = new URL(b);
+    ua.hash = "";
+    ub.hash = "";
+    return ua.href === ub.href;
+  } catch {
+    return false;
+  }
+}
+
 function buildAggregatedTools(): WsToolsListResponse["tools"] {
   const tools: WsToolsListResponse["tools"] = [];
   for (const [tabId, info] of tabTools) {
@@ -143,6 +156,9 @@ async function persistDomains() {
   });
 }
 
+// Resolves once the persisted activations are in memory. A service worker
+// restart re-runs this file, and a content script can report its tools before
+// storage has been read, so handlers that decide on activation wait for this.
 async function loadPersistedDomains() {
   const data = await chrome.storage.local.get(STORAGE_KEY);
   const domains: string[] = data[STORAGE_KEY] ?? [];
@@ -544,14 +560,23 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 
 // Clean up when tabs navigate
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
-  if (changeInfo.status === "loading") {
-    // Session-only activation doesn't survive navigation
-    activatedTabs.delete(tabId);
-    if (tabTools.has(tabId)) {
-      tabTools.delete(tabId);
-      rejectPendingCallsForTab(tabId);
-      notifyToolsChanged();
-    }
+  if (changeInfo.status !== "loading") return;
+
+  // A fragment change is a same-document navigation, which routers use for
+  // every in-app route: the document keeps the tools it registered and content
+  // scripts do not run again, so there would be nothing left to report them.
+  const known = tabTools.get(tabId);
+  if (known && changeInfo.url && isSameDocument(known.url, changeInfo.url)) {
+    if (DEBUG) console.log("[WebMCP Bridge] same-document navigation, keeping tools", changeInfo.url);
+    return;
+  }
+
+  // Session-only activation doesn't survive navigation
+  activatedTabs.delete(tabId);
+  if (tabTools.has(tabId)) {
+    tabTools.delete(tabId);
+    rejectPendingCallsForTab(tabId);
+    notifyToolsChanged();
   }
 });
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -170,6 +170,11 @@ async function loadPersistedDomains() {
   }
 }
 
+// Resolves once the persisted activations are in memory. A service worker
+// restart re-runs this file, and a content script can report its tools before
+// storage has been read, so handlers that decide on activation wait for this.
+const domainsReady: Promise<void> = loadPersistedDomains();
+
 async function registerContentScriptsForDomains(origins: string[]) {
   const scripts: chrome.scripting.RegisteredContentScript[] = [];
   for (const origin of origins) {
@@ -412,17 +417,26 @@ chrome.runtime.onMessage.addListener(
       case "TOOLS_UPDATED": {
         const tabId = sender.tab?.id;
         if (tabId == null) break;
-        if (!isTabAuthorized(tabId, sender.tab?.url)) {
-          // Stale content script from a deactivated tab — purge and ignore
-          purgeTabTools(tabId);
-          break;
-        }
-        tabTools.set(tabId, {
-          tools: message.tools,
-          title: sanitize(sender.tab?.title ?? "", 500),
-          url: sanitize(sender.tab?.url ?? "", 500),
+        const { tools } = message;
+        const url = sender.tab?.url;
+        const title = sender.tab?.title;
+        // An activated domain reads as unauthorized until storage has been
+        // read, and this branch purges rather than defers, so a page that
+        // registers during that window loses its tools until it registers
+        // again. Decide once the activations are in memory.
+        void domainsReady.then(() => {
+          if (!isTabAuthorized(tabId, url)) {
+            // Stale content script from a deactivated tab — purge and ignore
+            purgeTabTools(tabId);
+            return;
+          }
+          tabTools.set(tabId, {
+            tools,
+            title: sanitize(title ?? "", 500),
+            url: sanitize(url ?? "", 500),
+          });
+          notifyToolsChanged();
         });
-        notifyToolsChanged();
         break;
       }
       case "TOOL_RESULT": {
@@ -580,6 +594,5 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   }
 });
 
-// Load persisted domains and start WebSocket
-loadPersistedDomains();
+// Start the WebSocket; the persisted activations are already loading
 connectWebSocket();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,11 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    include: ["src/**/__tests__/**/*.test.{ts,tsx}", "examples/**/src/**/*.test.{ts,tsx}"],
+    include: [
+      "src/**/__tests__/**/*.test.{ts,tsx}",
+      "extension/src/**/__tests__/**/*.test.{ts,tsx}",
+      "examples/**/src/**/*.test.{ts,tsx}",
+    ],
     setupFiles: ["src/__tests__/setup.ts"],
     passWithNoTests: true,
   },


### PR DESCRIPTION
Three bugs that cost a tab its tools, each with a test that fails without its fix. Found while driving a hash-routed app through the bridge; the first one is the blocker.

**Tools vanish on the first in-app route change.** `tabs.onUpdated` fires `status: "loading"` for a fragment change, and every `"loading"` purged the tab. A same-document navigation does not re-run content scripts, so nothing reported the tools a second time — the page still had them, the bridge did not, and only re-activating the domain recovered it:

```
runtime.onMessage: TOOLS_UPDATED  tools: Array(3)
→ TOOLS_LIST with 3 tools
tabs.onUpdated {status: 'loading', url: 'http://localhost:3000/#/b'}
purge tab — navigation
→ TOOLS_LIST with 0 tools
```

**Tools purged during the service worker's startup.** A restart re-runs `background.ts` with an empty `activatedDomains` that `loadPersistedDomains` fills asynchronously. A report landing in that window fails `isTabAuthorized`, and that branch purges rather than defers.

**A stored activation outliving its host permission.** Reinstalling the extension keeps `chrome.storage.local` and drops its granted origins, so the popup reports a domain as active while `registerContentScripts` fails for it and the error is swallowed. Re-activating is the only way out, and nothing says so.

Adds a vitest harness for the extension — `chrome` and `WebSocket` mocked, `background.ts` imported fresh per test — and extends the vitest include to cover `extension/src`. Six tests, each red without its commit; the suite is 215 green.